### PR TITLE
fix: guarantee self_destruct runs on all exit paths in BaseWorker.main()

### DIFF
--- a/src/vastai_gpu_runner/worker/base.py
+++ b/src/vastai_gpu_runner/worker/base.py
@@ -59,34 +59,46 @@ class BaseWorker(ABC):
 
         Returns:
             Exit code (0 = success, 1 = workload failure, 3 = preflight gate).
+
+        Self-destruct always runs on exit, including when ``run_workload`` or
+        any earlier step raises an uncaught exception. Without this
+        guarantee, a subclass bug would leak a running Vast.ai instance and
+        keep billing indefinitely.
         """
-        os.chdir(self.workspace)
-        self.write_pid()
+        try:
+            os.chdir(self.workspace)
+            self.write_pid()
 
-        if not check_gpu(
-            min_memory_mib=self.min_gpu_memory_mib,
-            max_temp_c=self.max_gpu_temp_c,
-        ):
+            if not check_gpu(
+                min_memory_mib=self.min_gpu_memory_mib,
+                max_temp_c=self.max_gpu_temp_c,
+            ):
+                self._write_exit(1)
+                return 1
+
+            for gate in self.preflight_gates():
+                if not gate():
+                    gate_name = getattr(gate, "__name__", str(gate))
+                    logger.error("Preflight gate failed: %s", gate_name)
+                    self._write_exit(3)
+                    return 3
+
+            exit_code = self.run_workload()
+
+            self._write_exit(exit_code)
+            self._write_completed(exit_code == 0)
+
+            if exit_code == 0:
+                self.upload_results()
+
+            return exit_code
+        except Exception:
+            logger.exception("Unhandled exception in worker main()")
             self._write_exit(1)
+            self._write_completed(success=False)
             return 1
-
-        for gate in self.preflight_gates():
-            if not gate():
-                gate_name = getattr(gate, "__name__", str(gate))
-                logger.error("Preflight gate failed: %s", gate_name)
-                self._write_exit(3)
-                return 3
-
-        exit_code = self.run_workload()
-
-        self._write_exit(exit_code)
-        self._write_completed(exit_code == 0)
-
-        if exit_code == 0:
-            self.upload_results()
-
-        self.self_destruct()
-        return exit_code
+        finally:
+            self.self_destruct()
 
     # -- Hooks (override in subclasses) ------------------------------------
 

--- a/tests/test_worker_base.py
+++ b/tests/test_worker_base.py
@@ -165,3 +165,59 @@ class TestBaseWorker:
             with patch("urllib.request.urlopen", mock_urlopen):
                 worker.self_destruct()
             assert not mock_urlopen.called
+
+    def test_main_self_destruct_on_workload_exception(self, tmp_path: Path) -> None:
+        """run_workload() raising MUST still trigger self_destruct.
+
+        Regression test for the bug where an uncaught exception in any
+        subclass's run_workload() would leak a running Vast.ai instance
+        and keep billing indefinitely.
+        """
+
+        class RaisingWorker(BaseWorker):
+            def run_workload(self) -> int:
+                raise RuntimeError("boom")
+
+        worker = RaisingWorker(tmp_path)
+        destroy_calls: list[str] = []
+        with (
+            patch.object(worker, "write_pid"),
+            patch("vastai_gpu_runner.worker.base.check_gpu", return_value=True),
+            patch.object(worker, "_check_r2", return_value=True),
+            patch.object(worker, "self_destruct", side_effect=lambda: destroy_calls.append("x")),
+        ):
+            code = worker.main()
+
+        assert code == 1
+        assert destroy_calls == ["x"], "self_destruct must run in finally after exception"
+        assert (tmp_path / "worker.exitcode").read_text() == "1"
+        assert (tmp_path / "worker.completed").read_text() == "0"
+
+    def test_main_self_destruct_on_gpu_failure(self, tmp_path: Path) -> None:
+        """GPU check failure MUST still trigger self_destruct."""
+        worker = ConcreteWorker(tmp_path)
+        destroy_calls: list[str] = []
+        with (
+            patch.object(worker, "write_pid"),
+            patch("vastai_gpu_runner.worker.base.check_gpu", return_value=False),
+            patch.object(worker, "self_destruct", side_effect=lambda: destroy_calls.append("x")),
+        ):
+            code = worker.main()
+
+        assert code == 1
+        assert destroy_calls == ["x"]
+
+    def test_main_self_destruct_on_preflight_failure(self, tmp_path: Path) -> None:
+        """Preflight gate failure MUST still trigger self_destruct."""
+        worker = ConcreteWorker(tmp_path)
+        destroy_calls: list[str] = []
+        with (
+            patch.object(worker, "write_pid"),
+            patch("vastai_gpu_runner.worker.base.check_gpu", return_value=True),
+            patch.object(worker, "_check_r2", return_value=False),
+            patch.object(worker, "self_destruct", side_effect=lambda: destroy_calls.append("x")),
+        ):
+            code = worker.main()
+
+        assert code == 3
+        assert destroy_calls == ["x"]


### PR DESCRIPTION
## Summary

`BaseWorker.main()` previously called `run_workload()` bare. An uncaught exception in a subclass's `run_workload()` — or in `write_pid`, `check_gpu`, preflight gates, `_write_exit`, `_write_completed`, or `upload_results` — would propagate out without calling `self_destruct()`, leaving the Vast.ai instance running and billing indefinitely.

Wraps the body in `try/except/finally`:

- **try**: runs the full lifecycle as before.
- **except Exception**: logs, writes `exit=1`, writes `completed=False`, returns 1. Prevents the exception from escaping `main()` so the finally block still runs and the subprocess exits cleanly.
- **finally**: `self_destruct()` is always called. Self-destruct has its own internal exception handling so a failed API call here does not mask the real exit code.

## Why it matters

Every `BaseWorker` subclass (`Boltz2Worker`, `OpenMMWorker`, and any future one) now has exception-safe cleanup. This removes a class of silent billing leaks that were hard to distinguish from ordinary deployment failures — a crashed worker would look identical to a preempted worker from the orchestrator's point of view, and the instance would keep running until the next zombie sweep.

## Impact

- **No API change.** Existing subclasses don't need modification.
- **No behavior change for the success path** — the finally block self-destructs at the same point it used to.
- **Failure and exception paths now also self-destruct**, where before only the success path did reliably.

## Test plan

- [x] 3 new regression tests in `tests/test_worker_base.py`:
  - `test_main_self_destruct_on_workload_exception` — a `RaisingWorker` whose `run_workload()` raises `RuntimeError` must still trigger `self_destruct` and return exit code 1.
  - `test_main_self_destruct_on_gpu_failure` — GPU health check failure must still trigger `self_destruct`.
  - `test_main_self_destruct_on_preflight_failure` — preflight gate failure must still trigger `self_destruct`.
- [x] All 80 existing tests pass
- [x] `ruff format --check`, `ruff check`, `pyright` all clean

## Follow-up

This bug has been live since the BaseWorker migration in OralBiome-AMP's gen-2 branch landed. Any exception in a Boltz-2 prediction or OpenMM simulation worker on a cloud instance since then has likely leaked the instance. Worth spot-checking Vast.ai billing for unexpected charges, especially around the MD batch runs where \`run_workload\` interacts heavily with file IO and OpenMM/torch initialization — both common sources of uncaught exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)