### PR TITLE
feat(batch): add BatchOrchestrator ABC for parallel cloud GPU workloads

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,65 @@ Status flow: `pending` -> `deploying` -> `running` -> `completed` -> `downloaded
 | `check_gpu(min_memory_mib=0, max_temp_c=90)` | `bool` | nvidia-smi temp + ECC + optional VRAM check |
 | `check_r2_connectivity(workspace)` | `bool` | Run `r2_upload.py --check` if script exists |
 
-## Orchestrator (`vastai_gpu_runner.orchestrator`)
+## Batch orchestrator (`vastai_gpu_runner.batch`)
+
+`BatchOrchestrator[UnitT]` is the template-method ABC that coordinates deploy → poll → collect → cleanup across many units in parallel. Sits one layer above `CloudRunner`. Generic over unit type (`ShardState` or `JobState`).
+
+| Constructor parameter | Type | Default | Description |
+|-----------------------|------|---------|-------------|
+| `runner_factory` | `Callable[[], CloudRunner]` | required | Fresh `CloudRunner` per deploy attempt |
+| `label_prefix` | `str` | required | Instance label prefix for zombie-sweep filtering (unique per batch) |
+| `workspace_dir` | `str` | `"/workspace"` | Remote workspace path |
+| `r2_sink` | `R2Sink \| None` | `None` | Optional R2 sink for DONE-marker polling + recovery |
+| `r2_batch_id` | `str` | `""` | Batch ID for R2 marker lookups |
+| `budget_usd` | `float` | `0.0` | Hard cost ceiling (`0` disables) |
+| `max_retries` | `int` | `2` | Max re-deploys per unit on preemption |
+| `max_parallel_deploys` | `int` | `16` | Concurrent deploy threads |
+| `poll_interval_seconds` | `int` | `30` | Base poll cadence (exponential backoff) |
+| `zombie_sweep_every_n_cycles` | `int` | `5` | Run zombie sweep every N poll cycles |
+| `poll_timeout_seconds` | `float` | `0.0` | Hard poll deadline (`0` = no timeout) |
+
+### Domain hooks (subclasses must implement)
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `iter_pending_units()` | `Iterable[UnitT]` | Units to deploy |
+| `iter_active_units()` | `Iterable[UnitT]` | Units to poll |
+| `iter_failed_units()` | `Iterable[UnitT]` | Candidates for R2 recovery |
+| `iter_completed_units()` | `Iterable[UnitT]` | Terminal — skipped |
+| `save_state()` | `None` | Persist batch state atomically |
+| `unit_key(unit)` | `str` | Stable unique identifier |
+| `unit_label(unit)` | `str` | Human-readable label for logs |
+| `build_unit_payload(unit)` | `dict[str, Path]` | Files to upload |
+| `reconstruct_instance(unit)` | `CloudInstance` | Rebuild from persisted fields (resume) |
+| `collect_unit_results(unit, instance)` | `bool` | Download artifacts |
+| `unit_is_done_in_r2(unit)` | `bool` | R2 DONE marker check |
+| `classify_failure(unit, error)` | `"retry" \| "fatal"` | Retryable or permanent |
+
+### State-mutation event callbacks (subclasses must implement)
+
+| Method | Purpose |
+|--------|---------|
+| `on_unit_deployed(unit, instance)` | Set instance fields + status=deployed, save |
+| `on_unit_failed(unit, reason)` | Set status=failed, bump retry, save |
+| `on_unit_completed(unit)` | Set status=downloaded, save |
+| `on_unit_preempted(unit)` | Reset instance_id, status=pending, save |
+
+### Inherited lifecycle
+
+| Method | Description |
+|--------|-------------|
+| `run()` | Entry point: resume → deploy → sweep → poll → collect → cleanup |
+| `_resume_from_state()` | Rebuild live-runner map from persisted active units |
+| `_deploy_phase()` | Parallel deploy via `ThreadPoolExecutor` |
+| `_poll_phase()` | R2-first poll loop with exponential backoff |
+| `_check_unit(runner, instance, unit)` | Single-unit progress check with 3-layer rescue |
+| `_collect_phase()` | R2 recovery for failed-but-uploaded units |
+| `_cleanup_phase()` | Destroy leftover instances + final zombie sweep |
+| `_handle_instance_loss(unit, key, reason)` | Mark preempted; enforces `max_retries` cap |
+| `_sweep_zombies()` | Delegates to `orchestrator.sweep_zombie_instances` |
+
+## Orchestrator utils (`vastai_gpu_runner.orchestrator`)
 
 | Function | Returns | Description |
 |----------|---------|-------------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ vastai_gpu_runner/
     ssh.py                # ssh_cmd, scp_upload, scp_download
     state.py              # BatchState/ShardState + JobState/JobBatchState
     orchestrator.py       # sweep_zombies, ensure_detached, check_budget
+    batch.py              # BatchOrchestrator ABC — deploy/poll/collect lifecycle
     providers/
         vastai.py         # VastaiRunner — Vast.ai marketplace implementation
     storage/
@@ -29,7 +30,9 @@ vastai_gpu_runner/
 ┌─────────────────────────────────────────────────┐
 │  CLI (cli.py)                                   │  User-facing commands
 ├─────────────────────────────────────────────────┤
-│  Orchestrator (orchestrator.py)                 │  Zombie sweep, detach, budget
+│  BatchOrchestrator (batch.py)                   │  Deploy/poll/collect many units
+├─────────────────────────────────────────────────┤
+│  Orchestrator utils (orchestrator.py)           │  Zombie sweep, detach, budget
 ├─────────────────────────────────────────────────┤
 │  CloudRunner (runner.py)                        │  Provider-agnostic lifecycle
 ├─────────────────────────────────────────────────┤
@@ -68,6 +71,14 @@ class MyR2Sink(R2Sink):
 ### Atomic state persistence
 
 `BatchState.save()` writes to a temp file then renames. This guarantees the state file is never corrupt — even if the process crashes mid-write, the previous state file is intact.
+
+### Consumer-owned state, orchestrator-driven events
+
+`BatchOrchestrator` never mutates the consumer's `BatchState` / `JobBatchState` directly. Instead, it drives events (`on_unit_deployed`, `on_unit_failed`, `on_unit_completed`, `on_unit_preempted`) and the consumer updates its own fields, status strings, and retry counters. This keeps status-string vocabulary, retry accounting, and persistence format entirely in the consumer — so Boltz-2 and OpenMM can share the orchestration loop without sharing a state schema.
+
+### R2-first poll loop
+
+When an R2 sink is configured, the poll loop checks `unit_is_done_in_r2` *before* any SSH call. This matters in two places: (1) healthy-path completion detection is cheaper and works even if the SSH channel is flaky, and (2) when silent-crash detection fires (`worker_dead`), we re-check R2 one more time before treating the unit as preempted — the worker may have uploaded results and then died between the first R2 check and the SSH probe. Without the re-check, successful-but-crashed workers get unnecessarily re-deployed.
 
 ### SSH hardening
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -159,3 +159,127 @@ class InferenceWorker(BaseWorker):
                 timeout=300, check=False,
             )
 ```
+
+## Building a batch orchestrator
+
+`BatchOrchestrator[UnitT]` is the template-method ABC above `CloudRunner`. Subclass it when you need to deploy many GPU units in parallel with crash-recovery checkpoints, R2-first polling, preemption handling, and per-unit retry accounting. The ABC handles the lifecycle loop; you provide the domain hooks over your own batch-state type (`ShardState` or `JobState`).
+
+```python
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal
+
+from vastai_gpu_runner import BatchOrchestrator, CloudRunner
+from vastai_gpu_runner.providers.vastai import VastaiRunner
+from vastai_gpu_runner.state import BatchState, ShardState
+from vastai_gpu_runner.storage.r2 import R2Sink
+from vastai_gpu_runner.types import CloudInstance, DeploymentConfig
+
+
+class MyShardOrchestrator(BatchOrchestrator[ShardState]):
+    """Orchestrator over a shard-based BatchState."""
+
+    def __init__(
+        self,
+        state: BatchState,
+        state_path: Path,
+        output_dir: Path,
+        shard_inputs: dict[int, dict[str, Path]],
+        r2_sink: R2Sink,
+    ) -> None:
+        self._state = state
+        self._state_path = state_path
+        self._output_dir = output_dir
+        self._shard_inputs = shard_inputs
+        super().__init__(
+            runner_factory=lambda: VastaiRunner(DeploymentConfig()),
+            label_prefix=f"myproject-{state.batch_id[:8]}",
+            r2_sink=r2_sink,
+            r2_batch_id=state.batch_id,
+            budget_usd=50.0,
+            max_retries=2,
+        )
+
+    # -- State iteration ---------------------------------------------------
+
+    def iter_pending_units(self) -> Iterable[ShardState]:
+        return list(self._state.pending_shards)
+
+    def iter_active_units(self) -> Iterable[ShardState]:
+        return list(self._state.active_shards)
+
+    def iter_failed_units(self) -> Iterable[ShardState]:
+        return list(self._state.failed_shards)
+
+    def iter_completed_units(self) -> Iterable[ShardState]:
+        return list(self._state.downloaded_shards)
+
+    def save_state(self) -> None:
+        self._state.save(self._state_path)
+
+    def unit_key(self, unit: ShardState) -> str:
+        return str(unit.shard_id)
+
+    def unit_label(self, unit: ShardState) -> str:
+        return f"shard-{unit.shard_id}"
+
+    # -- Domain hooks ------------------------------------------------------
+
+    def build_unit_payload(self, unit: ShardState) -> dict[str, Path]:
+        return self._shard_inputs[unit.shard_id]
+
+    def reconstruct_instance(self, unit: ShardState) -> CloudInstance:
+        return CloudInstance(
+            instance_id=unit.instance_id,
+            ssh_host=unit.ssh_host,
+            ssh_port=unit.ssh_port,
+            cost_per_hour=unit.cost_per_hour,
+        )
+
+    def collect_unit_results(self, unit: ShardState, instance: CloudInstance) -> bool:
+        local = self._output_dir / f"shard_{unit.shard_id}"
+        # Consumer decides whether to use rsync, R2, or a hybrid.
+        return bool(self._r2_sink and self._r2_sink.download_shard(
+            self._state.batch_id, unit.shard_id, local,
+        ))
+
+    def unit_is_done_in_r2(self, unit: ShardState) -> bool:
+        if not self._r2_sink:
+            return False
+        return self._r2_sink.is_shard_done(self._state.batch_id, unit.shard_id)
+
+    def classify_failure(self, unit: ShardState, error: str) -> Literal["retry", "fatal"]:
+        if "input file missing" in error or "preflight" in error:
+            return "fatal"
+        return "retry"
+
+    # -- Event callbacks ---------------------------------------------------
+
+    def on_unit_deployed(self, unit: ShardState, instance: CloudInstance) -> None:
+        unit.instance_id = instance.instance_id
+        unit.ssh_host = instance.ssh_host
+        unit.ssh_port = instance.ssh_port
+        unit.cost_per_hour = instance.cost_per_hour
+        unit.status = "deployed"
+        self.save_state()
+
+    def on_unit_failed(self, unit: ShardState, reason: str) -> None:
+        unit.status = "failed"
+        unit.failure_reason = reason
+        unit.retry_count += 1
+        self.save_state()
+
+    def on_unit_completed(self, unit: ShardState) -> None:
+        unit.status = "downloaded"
+        self.save_state()
+
+    def on_unit_preempted(self, unit: ShardState) -> None:
+        unit.instance_id = ""
+        unit.status = "pending"
+        unit.retry_count += 1
+        self.save_state()
+```
+
+Call `orch.run()` to drive the full lifecycle. Everything else — parallel deploys, exponential-backoff polling, zombie sweeps, budget enforcement, R2-first completion checks, silent-crash detection, `max_retries` enforcement — is inherited.
+
+The same pattern works for job-based workloads: substitute `JobState` for `ShardState`, iterate over `JobBatchState.pending_jobs` / `.active_jobs` / `.completed_jobs`, and map `on_unit_completed` to `status="completed"` or `"downloaded"` to match your persistence format.

--- a/src/vastai_gpu_runner/__init__.py
+++ b/src/vastai_gpu_runner/__init__.py
@@ -37,6 +37,7 @@ Public API::
     )
 """
 
+from vastai_gpu_runner.batch import BatchOrchestrator, BatchUnit, FailureVerdict
 from vastai_gpu_runner.runner import CloudRunner
 from vastai_gpu_runner.types import (
     CloudInstance,
@@ -48,11 +49,14 @@ from vastai_gpu_runner.types import (
 )
 
 __all__ = [
+    "BatchOrchestrator",
+    "BatchUnit",
     "CloudInstance",
     "CloudRunner",
     "ComputeMode",
     "DeploymentConfig",
     "DeploymentResult",
+    "FailureVerdict",
     "InstanceStatus",
     "Provider",
 ]

--- a/src/vastai_gpu_runner/batch.py
+++ b/src/vastai_gpu_runner/batch.py
@@ -1,0 +1,559 @@
+"""Batch orchestrator for cloud GPU workloads.
+
+``BatchOrchestrator`` is the template-method ABC that sits one layer above
+``CloudRunner``. Where ``CloudRunner`` handles the lifecycle of a *single*
+instance (search → create → boot → verify → deploy → launch → poll →
+download → destroy), ``BatchOrchestrator`` coordinates the lifecycle of
+*many* units in parallel — deploying, polling, classifying failures,
+handling instance loss, and resuming from a crash-recovery checkpoint.
+
+A "unit" is either a shard (``ShardState``, N items per GPU) or a job
+(``JobState``, 1 item per GPU). Consumers choose the shape by implementing
+the ``iter_*`` hook methods over their own batch-state type.
+
+Design principles:
+
+1. **No provider coupling.** The orchestrator talks to a ``CloudRunner``
+   factory exclusively. Vast.ai, RunPod, or a mock all work the same.
+
+2. **Consumer owns state.** The orchestrator drives *events*
+   (``on_unit_deployed``, ``on_unit_failed``, ``on_unit_completed``,
+   ``on_unit_preempted``); the consumer updates its own ``BatchState`` /
+   ``JobBatchState`` object and persists it via ``save_state``. Status
+   strings, field names, and retry accounting all live in consumer code.
+
+3. **Hooks are narrow.** The orchestrator asks the consumer:
+   - What units are pending / active / completed? (``iter_*``)
+   - What files does this unit need? (``build_unit_payload``)
+   - Can I reconstruct a live instance on resume? (``reconstruct_instance``)
+   - Where do I download results? (``collect_unit_results``)
+   - Is this unit already done in R2? (``unit_is_done_in_r2``)
+   - How do I label it in logs? (``unit_label``)
+   - Is this failure retryable? (``classify_failure``)
+
+4. **Drift-free symmetry.** Boltz-2 and OpenMM share exactly the same
+   orchestration loop via this class. Bug fixes land once.
+
+Usage sketch::
+
+    class MyOrch(BatchOrchestrator[ShardState]):
+        def __init__(self, state: BatchState, ...):
+            super().__init__(...)
+            self._state = state
+
+        def iter_pending_units(self):
+            return list(self._state.pending_shards)
+
+        def on_unit_deployed(self, unit, instance):
+            unit.instance_id = instance.instance_id
+            unit.ssh_host = instance.ssh_host
+            unit.ssh_port = instance.ssh_port
+            unit.cost_per_hour = instance.cost_per_hour
+            unit.status = "deployed"
+            self.save_state()
+
+        # ... etc
+
+The ABC does NOT handle: weight uploads, local GPU hybrid mode, shard input
+preparation. Those live in the consumer. The ABC handles only the cloud
+lifecycle loop.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING, Generic, Literal, Protocol, TypeVar
+
+from vastai_gpu_runner.orchestrator import check_budget, sweep_zombie_instances
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from vastai_gpu_runner.runner import CloudRunner
+    from vastai_gpu_runner.storage.r2 import R2Sink
+    from vastai_gpu_runner.types import CloudInstance
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+class BatchUnit(Protocol):
+    """Structural type for one unit of work in a batch.
+
+    Both ``state.ShardState`` and ``state.JobState`` satisfy this protocol.
+    """
+
+    instance_id: str
+    ssh_host: str
+    ssh_port: int
+    cost_per_hour: float
+    status: str
+    retry_count: int
+
+
+RunnerFactory = Callable[[], "CloudRunner"]
+"""Factory returning a fresh ``CloudRunner`` for one deploy attempt."""
+
+
+UnitT = TypeVar("UnitT", bound=BatchUnit)
+
+FailureVerdict = Literal["retry", "fatal"]
+
+
+# ---------------------------------------------------------------------------
+# BatchOrchestrator ABC
+# ---------------------------------------------------------------------------
+
+
+class BatchOrchestrator(ABC, Generic[UnitT]):
+    """Abstract batch orchestrator for cloud GPU workloads.
+
+    See module docstring for design overview. Generic over unit type
+    (``ShardState`` or ``JobState``).
+    """
+
+    def __init__(
+        self,
+        *,
+        runner_factory: RunnerFactory,
+        label_prefix: str,
+        workspace_dir: str = "/workspace",
+        r2_sink: R2Sink | None = None,
+        r2_batch_id: str = "",
+        budget_usd: float = 0.0,
+        max_retries: int = 2,
+        max_parallel_deploys: int = 16,
+        poll_interval_seconds: int = 30,
+        zombie_sweep_every_n_cycles: int = 5,
+        poll_timeout_seconds: float = 0.0,
+    ) -> None:
+        """Initialise orchestrator state. See class docstring for argument meanings."""
+        self._runner_factory = runner_factory
+        self._label_prefix = label_prefix
+        self._workspace_dir = workspace_dir
+        self._r2_sink = r2_sink
+        self._r2_batch_id = r2_batch_id
+        self._budget_usd = budget_usd
+        self._max_retries = max_retries
+        self._max_parallel_deploys = max_parallel_deploys
+        self._poll_interval_seconds = poll_interval_seconds
+        self._zombie_sweep_every_n_cycles = zombie_sweep_every_n_cycles
+        self._poll_timeout_seconds = poll_timeout_seconds
+
+        # Live runner registry: unit_key → (runner, instance, unit)
+        self._live_runners: dict[str, tuple[CloudRunner, CloudInstance, UnitT]] = {}
+        self._state_lock = threading.Lock()
+        self._used_machine_ids: set[str] = set()
+
+    # -- Domain hooks (subclasses override) --------------------------------
+
+    @abstractmethod
+    def iter_pending_units(self) -> Iterable[UnitT]:
+        """Units that have not yet been deployed (status == pending)."""
+
+    @abstractmethod
+    def iter_active_units(self) -> Iterable[UnitT]:
+        """Units that are currently deployed or running (need polling)."""
+
+    @abstractmethod
+    def iter_failed_units(self) -> Iterable[UnitT]:
+        """Units that failed and may be eligible for re-deploy."""
+
+    @abstractmethod
+    def iter_completed_units(self) -> Iterable[UnitT]:
+        """Units whose results have been downloaded (terminal, skip)."""
+
+    @abstractmethod
+    def save_state(self) -> None:
+        """Persist batch state atomically. Called after every event."""
+
+    @abstractmethod
+    def unit_key(self, unit: UnitT) -> str:
+        """Stable unique identifier for this unit (shard_id, job_name, ...)."""
+
+    @abstractmethod
+    def unit_label(self, unit: UnitT) -> str:
+        """Human-readable identifier for logs."""
+
+    @abstractmethod
+    def build_unit_payload(self, unit: UnitT) -> dict[str, Path]:
+        """Files to upload for this unit. Maps remote relative path → local path."""
+
+    @abstractmethod
+    def reconstruct_instance(self, unit: UnitT) -> CloudInstance:
+        """Rebuild a ``CloudInstance`` from persisted unit fields (for resume)."""
+
+    @abstractmethod
+    def collect_unit_results(self, unit: UnitT, instance: CloudInstance) -> bool:
+        """Download artifacts for one completed unit. True on success."""
+
+    @abstractmethod
+    def unit_is_done_in_r2(self, unit: UnitT) -> bool:
+        """Whether this unit's results already exist in R2. False if no R2 sink."""
+
+    @abstractmethod
+    def classify_failure(self, unit: UnitT, error: str) -> FailureVerdict:
+        """Classify a failure as retryable or fatal."""
+
+    # -- State-mutation events (subclasses override) -----------------------
+
+    @abstractmethod
+    def on_unit_deployed(self, unit: UnitT, instance: CloudInstance) -> None:
+        """Consumer: set instance_id/ssh_*/cost_per_hour/status='deployed'; save_state."""
+
+    @abstractmethod
+    def on_unit_failed(self, unit: UnitT, reason: str) -> None:
+        """Consumer: set status='failed', failure_reason, bump retry_count; save_state."""
+
+    @abstractmethod
+    def on_unit_completed(self, unit: UnitT) -> None:
+        """Consumer: set status='downloaded' after collect_unit_results succeeded; save_state."""
+
+    @abstractmethod
+    def on_unit_preempted(self, unit: UnitT) -> None:
+        """Consumer: reset instance_id='', status='pending' for redeploy; save_state."""
+
+    # -- Concrete lifecycle (inherited) ------------------------------------
+
+    def run(self) -> None:
+        """Run the batch end-to-end: resume → deploy → poll → collect → cleanup."""
+        logger.info("BatchOrchestrator: starting batch %s", self._label_prefix)
+        self._resume_from_state()
+        self._deploy_phase()
+        self._sweep_zombies()
+        self._poll_phase()
+        self._collect_phase()
+        self._cleanup_phase()
+        logger.info("BatchOrchestrator: batch %s complete", self._label_prefix)
+
+    # -- Phase 1: resume ---------------------------------------------------
+
+    def _resume_from_state(self) -> None:
+        """Reconstruct live-runner map from already-active units."""
+        for unit in self.iter_active_units():
+            if not unit.instance_id:
+                continue
+            try:
+                instance = self.reconstruct_instance(unit)
+                runner = self._runner_factory()
+                self._live_runners[self.unit_key(unit)] = (runner, instance, unit)
+                logger.info(
+                    "Resume: reconnected to %s on instance %s",
+                    self.unit_label(unit),
+                    unit.instance_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Resume: failed to reconnect %s: %s — will re-deploy",
+                    self.unit_label(unit),
+                    exc,
+                )
+                self.on_unit_preempted(unit)
+
+    # -- Phase 2: deploy ---------------------------------------------------
+
+    def _deploy_phase(self) -> None:
+        """Parallel deploy of pending units via ThreadPoolExecutor."""
+        pending = [u for u in self.iter_pending_units() if not self.unit_is_done_in_r2(u)]
+        if not pending:
+            logger.info("Deploy phase: no pending units")
+            return
+
+        if self._budget_usd > 0 and not check_budget(0.0, self._budget_usd):
+            logger.error("Deploy phase: budget exceeded before deploy")
+            for unit in pending:
+                self.on_unit_failed(unit, "budget exceeded")
+            return
+
+        max_workers = min(self._max_parallel_deploys, len(pending))
+        logger.info(
+            "Deploy phase: %d unit(s) across %d worker(s)",
+            len(pending),
+            max_workers,
+        )
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(self._deploy_one, u): u for u in pending}
+            for fut in as_completed(futures):
+                unit = futures[fut]
+                try:
+                    ok = fut.result()
+                except Exception as exc:
+                    logger.exception("Deploy %s raised: %s", self.unit_label(unit), exc)
+                    with self._state_lock:
+                        self.on_unit_failed(unit, f"deploy exception: {exc}")
+                    continue
+                if ok:
+                    logger.info("Deploy %s: success", self.unit_label(unit))
+                else:
+                    logger.warning("Deploy %s: failed", self.unit_label(unit))
+
+    def _deploy_one(self, unit: UnitT) -> bool:
+        """Deploy a single unit. Thread-safe via ``self._state_lock``."""
+        runner = self._runner_factory()
+        files = self.build_unit_payload(unit)
+
+        try:
+            # CloudRunner.run_full_cycle does boot, verify, deploy, setup, launch.
+            result = runner.run_full_cycle(
+                files=files,
+                local_output_dir=self._workspace_local_for(unit),
+                max_retries=3,
+                used_machine_ids=self._used_machine_ids,
+                machine_lock=self._state_lock,
+            )
+        except Exception as exc:
+            with self._state_lock:
+                self.on_unit_failed(unit, f"run_full_cycle exception: {exc}")
+            return False
+
+        with self._state_lock:
+            if result.success and result.instance is not None:
+                self._live_runners[self.unit_key(unit)] = (runner, result.instance, unit)
+                self.on_unit_deployed(unit, result.instance)
+                return True
+            self.on_unit_failed(unit, result.error or "deploy failed")
+            return False
+
+    def _workspace_local_for(self, unit: UnitT) -> Path:
+        """Default local workspace path. Override in subclass for custom layout."""
+        from pathlib import Path as _Path
+
+        return _Path.cwd() / "outputs" / self.unit_label(unit)
+
+    # -- Phase 3: poll -----------------------------------------------------
+
+    def _poll_phase(self) -> None:
+        """Poll until all live units terminal. Exponential backoff + R2-first."""
+        if not self._live_runners:
+            logger.info("Poll phase: no live runners")
+            return
+
+        base = self._poll_interval_seconds
+        cur_interval = min(base, 5)
+        max_interval = min(base * 2, 60)
+        deadline = (
+            time.time() + self._poll_timeout_seconds
+            if self._poll_timeout_seconds > 0
+            else float("inf")
+        )
+        cycle = 0
+
+        while self._live_runners and time.time() < deadline:
+            cycle += 1
+
+            if cycle % self._zombie_sweep_every_n_cycles == 0:
+                self._sweep_zombies()
+
+            if self._budget_usd > 0 and not check_budget(
+                self._estimate_current_spend(),
+                self._budget_usd,
+            ):
+                logger.error("Poll phase: budget exceeded — aborting")
+                break
+
+            any_made_progress = False
+            for unit_key in list(self._live_runners.keys()):
+                entry = self._live_runners.get(unit_key)
+                if entry is None:
+                    continue
+                runner, instance, unit = entry
+
+                verdict = self._check_unit(runner, instance, unit)
+                if verdict == "completed":
+                    any_made_progress = True
+                elif verdict == "preempted":
+                    any_made_progress = True
+
+            if any_made_progress:
+                cur_interval = min(base, 5)
+            else:
+                time.sleep(cur_interval)
+                cur_interval = min(cur_interval * 2, max_interval)
+
+        if time.time() >= deadline and self._live_runners:
+            logger.warning(
+                "Poll phase: timeout after %.0fs with %d live units",
+                self._poll_timeout_seconds,
+                len(self._live_runners),
+            )
+
+    def _check_unit(
+        self,
+        runner: CloudRunner,
+        instance: CloudInstance,
+        unit: UnitT,
+    ) -> Literal["completed", "running", "preempted", "failed"]:
+        """Single-unit poll cycle. R2-first, then SSH fallback + rescue."""
+        unit_key = self.unit_key(unit)
+
+        # Layer 1: R2 DONE marker (works even if SSH is flaky)
+        if self.unit_is_done_in_r2(unit):
+            return self._finalise_completed(runner, instance, unit, unit_key)
+
+        # Layer 2: SSH progress check
+        try:
+            progress = runner.check_progress(instance)
+        except Exception as exc:
+            logger.warning(
+                "Poll %s: check_progress raised %s — treating as running",
+                self.unit_label(unit),
+                exc,
+            )
+            return "running"
+
+        if progress.get("complete"):
+            return self._finalise_completed(runner, instance, unit, unit_key)
+
+        # Layer 3: silent worker crash detection
+        if progress.get("worker_dead"):
+            # Re-check R2 once more — worker may have uploaded results
+            # between the check above and now.
+            if self.unit_is_done_in_r2(unit):
+                return self._finalise_completed(runner, instance, unit, unit_key)
+            logger.warning(
+                "Poll %s: worker dead on %s — handling as instance loss",
+                self.unit_label(unit),
+                unit.instance_id,
+            )
+            with contextlib.suppress(Exception):
+                runner.destroy_instance(instance)
+            with self._state_lock:
+                self._handle_instance_loss(unit, unit_key, "worker died silently")
+            return "preempted"
+
+        return "running"
+
+    def _finalise_completed(
+        self,
+        runner: CloudRunner,
+        instance: CloudInstance,
+        unit: UnitT,
+        unit_key: str,
+    ) -> Literal["completed", "failed"]:
+        """Download results, call on_unit_completed, destroy instance."""
+        ok = False
+        try:
+            ok = self.collect_unit_results(unit, instance)
+        except Exception as exc:
+            logger.exception(
+                "Collect %s raised: %s",
+                self.unit_label(unit),
+                exc,
+            )
+        with self._state_lock:
+            if ok:
+                self.on_unit_completed(unit)
+            else:
+                self.on_unit_failed(unit, "collect_unit_results failed")
+            self._live_runners.pop(unit_key, None)
+        with contextlib.suppress(Exception):
+            runner.destroy_instance(instance)
+        return "completed" if ok else "failed"
+
+    # -- Phase 4: collect any stragglers (R2 recovery for failed units) ----
+
+    def _collect_phase(self) -> None:
+        """After poll, try R2 recovery for units that failed with uploaded results."""
+        if self._r2_sink is None:
+            return
+        for unit in list(self.iter_failed_units()):
+            if not self.unit_is_done_in_r2(unit):
+                continue
+            logger.info(
+                "R2 recovery: %s is done in R2 — collecting",
+                self.unit_label(unit),
+            )
+            try:
+                instance = self.reconstruct_instance(unit)
+            except Exception:
+                # No live instance — consumer's collect_unit_results must
+                # handle this path (e.g. download from R2 directly).
+                from vastai_gpu_runner.types import CloudInstance as _CloudInstance
+
+                instance = _CloudInstance()
+            try:
+                if self.collect_unit_results(unit, instance):
+                    with self._state_lock:
+                        self.on_unit_completed(unit)
+            except Exception as exc:
+                logger.warning(
+                    "R2 recovery collect failed for %s: %s",
+                    self.unit_label(unit),
+                    exc,
+                )
+
+    # -- Phase 5: cleanup --------------------------------------------------
+
+    def _cleanup_phase(self) -> None:
+        """Destroy any leftover live instances. Final zombie sweep."""
+        for runner, instance, unit in list(self._live_runners.values()):
+            logger.warning(
+                "Cleanup: destroying leftover instance for %s",
+                self.unit_label(unit),
+            )
+            with contextlib.suppress(Exception):
+                runner.destroy_instance(instance)
+        self._live_runners.clear()
+        self._sweep_zombies()
+
+    # -- Instance loss handling --------------------------------------------
+
+    def _handle_instance_loss(
+        self,
+        unit: UnitT,
+        unit_key: str,
+        reason: str,
+    ) -> bool:
+        """Mark unit preempted and remove from live map. Caller must hold lock.
+
+        Returns True if the unit is eligible for re-deploy (retry_count
+        under cap), False if it should be marked fatally failed. The
+        actual re-deploy happens in the next deploy_phase iteration
+        (not implemented as an in-poll redeploy in this ABC — the
+        consumer can call ``_deploy_phase`` again if desired).
+        """
+        self._live_runners.pop(unit_key, None)
+        if unit.retry_count >= self._max_retries:
+            self.on_unit_failed(unit, f"{reason} (retries exhausted)")
+            return False
+        verdict = self.classify_failure(unit, reason)
+        if verdict == "fatal":
+            self.on_unit_failed(unit, f"{reason} (fatal)")
+            return False
+        self.on_unit_preempted(unit)
+        return True
+
+    # -- Zombie sweep + budget --------------------------------------------
+
+    def _sweep_zombies(self) -> int:
+        """Destroy Vast.ai instances not tracked by live_runners."""
+        with self._state_lock:
+            live_map: dict[int, tuple[CloudRunner, CloudInstance]] = {
+                i: (entry[0], entry[1]) for i, entry in enumerate(self._live_runners.values())
+            }
+        try:
+            return sweep_zombie_instances(
+                live_map,
+                label_prefix=self._label_prefix,
+                r2_sink=self._r2_sink,
+                r2_batch_id=self._r2_batch_id,
+            )
+        except Exception as exc:
+            logger.warning("Zombie sweep failed: %s", exc)
+            return 0
+
+    def _estimate_current_spend(self) -> float:
+        """Estimate current batch spend. Override for provider-specific tracking."""
+        # Default: no spend tracking. Subclasses can override to sum
+        # (now - start_time) * cost_per_hour across all units.
+        return 0.0

--- a/src/vastai_gpu_runner/batch.py
+++ b/src/vastai_gpu_runner/batch.py
@@ -341,39 +341,17 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
         base = self._poll_interval_seconds
         cur_interval = min(base, 5)
         max_interval = min(base * 2, 60)
-        deadline = (
-            time.time() + self._poll_timeout_seconds
-            if self._poll_timeout_seconds > 0
-            else float("inf")
-        )
+        deadline = self._compute_poll_deadline()
         cycle = 0
 
         while self._live_runners and time.time() < deadline:
             cycle += 1
-
             if cycle % self._zombie_sweep_every_n_cycles == 0:
                 self._sweep_zombies()
-
-            if self._budget_usd > 0 and not check_budget(
-                self._estimate_current_spend(),
-                self._budget_usd,
-            ):
-                logger.error("Poll phase: budget exceeded — aborting")
+            if not self._poll_budget_ok():
                 break
 
-            any_made_progress = False
-            for unit_key in list(self._live_runners.keys()):
-                entry = self._live_runners.get(unit_key)
-                if entry is None:
-                    continue
-                runner, instance, unit = entry
-
-                verdict = self._check_unit(runner, instance, unit)
-                if verdict == "completed":
-                    any_made_progress = True
-                elif verdict == "preempted":
-                    any_made_progress = True
-
+            any_made_progress = self._poll_cycle_once()
             if any_made_progress:
                 cur_interval = min(base, 5)
             else:
@@ -386,6 +364,34 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
                 self._poll_timeout_seconds,
                 len(self._live_runners),
             )
+
+    def _compute_poll_deadline(self) -> float:
+        """Absolute wall-clock deadline for the poll loop. ``inf`` when disabled."""
+        if self._poll_timeout_seconds > 0:
+            return time.time() + self._poll_timeout_seconds
+        return float("inf")
+
+    def _poll_budget_ok(self) -> bool:
+        """Check budget ceiling. Returns False if poll loop should abort."""
+        if self._budget_usd <= 0:
+            return True
+        if not check_budget(self._estimate_current_spend(), self._budget_usd):
+            logger.error("Poll phase: budget exceeded — aborting")
+            return False
+        return True
+
+    def _poll_cycle_once(self) -> bool:
+        """One sweep over live units. Returns True if any unit made progress."""
+        any_progress = False
+        for unit_key in list(self._live_runners.keys()):
+            entry = self._live_runners.get(unit_key)
+            if entry is None:
+                continue
+            runner, instance, unit = entry
+            verdict = self._check_unit(runner, instance, unit)
+            if verdict in ("completed", "preempted"):
+                any_progress = True
+        return any_progress
 
     def _check_unit(
         self,

--- a/src/vastai_gpu_runner/batch.py
+++ b/src/vastai_gpu_runner/batch.py
@@ -67,7 +67,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Generic, Literal, Protocol, TypeVar
 
 from vastai_gpu_runner.orchestrator import check_budget, sweep_zombie_instances
@@ -268,34 +268,42 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
         if not pending:
             logger.info("Deploy phase: no pending units")
             return
-
-        if self._budget_usd > 0 and not check_budget(0.0, self._budget_usd):
-            logger.error("Deploy phase: budget exceeded before deploy")
-            for unit in pending:
-                self.on_unit_failed(unit, "budget exceeded")
+        if not self._deploy_budget_ok(pending):
             return
 
         max_workers = min(self._max_parallel_deploys, len(pending))
-        logger.info(
-            "Deploy phase: %d unit(s) across %d worker(s)",
-            len(pending),
-            max_workers,
-        )
+        logger.info("Deploy phase: %d unit(s) across %d worker(s)", len(pending), max_workers)
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(self._deploy_one, u): u for u in pending}
             for fut in as_completed(futures):
-                unit = futures[fut]
-                try:
-                    ok = fut.result()
-                except Exception as exc:
-                    logger.exception("Deploy %s raised: %s", self.unit_label(unit), exc)
-                    with self._state_lock:
-                        self.on_unit_failed(unit, f"deploy exception: {exc}")
-                    continue
-                if ok:
-                    logger.info("Deploy %s: success", self.unit_label(unit))
-                else:
-                    logger.warning("Deploy %s: failed", self.unit_label(unit))
+                self._handle_deploy_future(fut, futures[fut])
+
+    def _deploy_budget_ok(self, pending: list[UnitT]) -> bool:
+        """Pre-flight budget check. Marks all pending units failed if exceeded."""
+        if self._budget_usd <= 0 or check_budget(0.0, self._budget_usd):
+            return True
+        logger.error("Deploy phase: budget exceeded before deploy")
+        for unit in pending:
+            self.on_unit_failed(unit, "budget exceeded")
+        return False
+
+    def _handle_deploy_future(
+        self,
+        fut: Future[bool],
+        unit: UnitT,
+    ) -> None:
+        """Translate one deploy future into an event + log line."""
+        try:
+            ok = fut.result()
+        except Exception as exc:
+            logger.exception("Deploy %s raised: %s", self.unit_label(unit), exc)
+            with self._state_lock:
+                self.on_unit_failed(unit, f"deploy exception: {exc}")
+            return
+        if ok:
+            logger.info("Deploy %s: success", self.unit_label(unit))
+        else:
+            logger.warning("Deploy %s: failed", self.unit_label(unit))
 
     def _deploy_one(self, unit: UnitT) -> bool:
         """Deploy a single unit. Thread-safe via ``self._state_lock``."""
@@ -346,18 +354,36 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
 
         while self._live_runners and time.time() < deadline:
             cycle += 1
-            if cycle % self._zombie_sweep_every_n_cycles == 0:
-                self._sweep_zombies()
-            if not self._poll_budget_ok():
+            if not self._poll_pre_iteration(cycle):
                 break
+            any_progress = self._poll_cycle_once()
+            cur_interval = self._advance_poll_interval(
+                any_progress, cur_interval, base, max_interval
+            )
 
-            any_made_progress = self._poll_cycle_once()
-            if any_made_progress:
-                cur_interval = min(base, 5)
-            else:
-                time.sleep(cur_interval)
-                cur_interval = min(cur_interval * 2, max_interval)
+        self._warn_on_poll_timeout(deadline)
 
+    def _poll_pre_iteration(self, cycle: int) -> bool:
+        """Run zombie sweep + budget check. Returns False to abort the loop."""
+        if cycle % self._zombie_sweep_every_n_cycles == 0:
+            self._sweep_zombies()
+        return self._poll_budget_ok()
+
+    @staticmethod
+    def _advance_poll_interval(
+        any_progress: bool,
+        cur_interval: int,
+        base: int,
+        max_interval: int,
+    ) -> int:
+        """Apply exponential backoff: reset on progress, else sleep + double up to cap."""
+        if any_progress:
+            return min(base, 5)
+        time.sleep(cur_interval)
+        return min(cur_interval * 2, max_interval)
+
+    def _warn_on_poll_timeout(self, deadline: float) -> None:
+        """Emit a warning if the poll loop exited on timeout with live units still active."""
         if time.time() >= deadline and self._live_runners:
             logger.warning(
                 "Poll phase: timeout after %.0fs with %d live units",

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,652 @@
+"""Tests for BatchOrchestrator ABC.
+
+Uses a mock CloudRunner and a concrete in-memory orchestrator subclass.
+No real Vast.ai calls, no SSH. Covers:
+
+- deploy phase success and failure
+- poll phase: R2-first, SSH fallback, silent-crash detection
+- resume from active units (reconstruct live runners)
+- retry cap → fatal after retries exhausted
+- collect phase: R2 recovery for failed-but-uploaded units
+- cleanup phase: destroys leftover instances
+- full run() lifecycle end-to-end
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vastai_gpu_runner.batch import BatchOrchestrator, FailureVerdict
+from vastai_gpu_runner.runner import CloudRunner
+from vastai_gpu_runner.types import CloudInstance, DeploymentResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+# ---------------------------------------------------------------------------
+# Fake unit + concrete orchestrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeUnit:
+    """In-memory unit for tests. Mirrors ShardState/JobState shape."""
+
+    key: str
+    instance_id: str = ""
+    ssh_host: str = ""
+    ssh_port: int = 0
+    cost_per_hour: float = 0.0
+    status: str = "pending"
+    retry_count: int = 0
+    failure_reason: str = ""
+    done_in_r2: bool = False
+    collect_result: bool = True
+    events: list[str] = field(default_factory=list)
+
+
+class FakeOrchestrator(BatchOrchestrator[FakeUnit]):
+    """Test orchestrator that owns a list of FakeUnits and records events."""
+
+    def __init__(self, units: list[FakeUnit], **kwargs: object) -> None:
+        self.units = units
+        self.state_saves = 0
+        self.payload_builds: list[str] = []
+        self.collect_calls: list[str] = []
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+
+    def iter_pending_units(self) -> Iterable[FakeUnit]:
+        return [u for u in self.units if u.status == "pending"]
+
+    def iter_active_units(self) -> Iterable[FakeUnit]:
+        return [u for u in self.units if u.status in ("deployed", "running")]
+
+    def iter_failed_units(self) -> Iterable[FakeUnit]:
+        return [u for u in self.units if u.status == "failed"]
+
+    def iter_completed_units(self) -> Iterable[FakeUnit]:
+        return [u for u in self.units if u.status == "downloaded"]
+
+    def save_state(self) -> None:
+        self.state_saves += 1
+
+    def unit_key(self, unit: FakeUnit) -> str:
+        return unit.key
+
+    def unit_label(self, unit: FakeUnit) -> str:
+        return unit.key
+
+    def build_unit_payload(self, unit: FakeUnit) -> dict[str, Path]:
+        self.payload_builds.append(unit.key)
+        return {"input.txt": Path("/tmp/fake")}
+
+    def reconstruct_instance(self, unit: FakeUnit) -> CloudInstance:
+        return CloudInstance(
+            instance_id=unit.instance_id,
+            ssh_host=unit.ssh_host,
+            ssh_port=unit.ssh_port,
+        )
+
+    def collect_unit_results(self, unit: FakeUnit, instance: CloudInstance) -> bool:
+        del instance
+        self.collect_calls.append(unit.key)
+        return unit.collect_result
+
+    def unit_is_done_in_r2(self, unit: FakeUnit) -> bool:
+        return unit.done_in_r2
+
+    def classify_failure(self, unit: FakeUnit, error: str) -> FailureVerdict:
+        del unit, error
+        return "retry"
+
+    def on_unit_deployed(self, unit: FakeUnit, instance: CloudInstance) -> None:
+        unit.instance_id = instance.instance_id
+        unit.ssh_host = instance.ssh_host
+        unit.ssh_port = instance.ssh_port
+        unit.cost_per_hour = instance.cost_per_hour
+        unit.status = "deployed"
+        unit.events.append("deployed")
+        self.save_state()
+
+    def on_unit_failed(self, unit: FakeUnit, reason: str) -> None:
+        unit.status = "failed"
+        unit.failure_reason = reason
+        unit.retry_count += 1
+        unit.events.append(f"failed:{reason}")
+        self.save_state()
+
+    def on_unit_completed(self, unit: FakeUnit) -> None:
+        unit.status = "downloaded"
+        unit.events.append("completed")
+        self.save_state()
+
+    def on_unit_preempted(self, unit: FakeUnit) -> None:
+        unit.instance_id = ""
+        unit.status = "pending"
+        unit.retry_count += 1
+        unit.events.append("preempted")
+        self.save_state()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok_deploy(instance_id: str = "inst-1") -> DeploymentResult:
+    return DeploymentResult(
+        success=True,
+        instance=CloudInstance(
+            instance_id=instance_id,
+            ssh_host="1.2.3.4",
+            ssh_port=22,
+            cost_per_hour=0.5,
+        ),
+    )
+
+
+def _fail_deploy(error: str = "boot timeout") -> DeploymentResult:
+    return DeploymentResult(success=False, error=error)
+
+
+def _mock_runner_factory(
+    *,
+    deploy_result: DeploymentResult,
+    progress: dict[str, object] | None = None,
+) -> object:
+    """Build a factory returning mock CloudRunners with controlled behaviour."""
+
+    def factory() -> CloudRunner:
+        r = CloudRunner()
+        r.run_full_cycle = MagicMock(return_value=deploy_result)  # type: ignore[method-assign]
+        r.check_progress = MagicMock(  # type: ignore[method-assign]
+            return_value=progress or {"running": True, "complete": False}
+        )
+        r.destroy_instance = MagicMock(return_value=True)  # type: ignore[method-assign]
+        return r
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Deploy phase
+# ---------------------------------------------------------------------------
+
+
+class TestDeployPhase:
+    def test_deploy_success_sets_live_runner_and_event(self) -> None:
+        unit = FakeUnit(key="u1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy("inst-42")),
+            label_prefix="test",
+        )
+        orch._deploy_phase()
+
+        assert unit.status == "deployed"
+        assert unit.instance_id == "inst-42"
+        assert unit.events == ["deployed"]
+        assert "u1" in [orch.unit_key(u) for _, _, u in orch._live_runners.values()]
+
+    def test_deploy_failure_marks_failed(self) -> None:
+        unit = FakeUnit(key="u1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_fail_deploy("no offers")),
+            label_prefix="test",
+        )
+        orch._deploy_phase()
+
+        assert unit.status == "failed"
+        assert "no offers" in unit.failure_reason
+        assert unit.retry_count == 1
+        assert not orch._live_runners
+
+    def test_deploy_skips_units_already_done_in_r2(self) -> None:
+        unit = FakeUnit(key="u1", done_in_r2=True)
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        orch._deploy_phase()
+
+        assert unit.status == "pending"  # unchanged
+        assert unit.events == []
+        assert orch.payload_builds == []  # no deploy attempted
+
+    def test_deploy_budget_exceeded_fails_all(self) -> None:
+        unit1 = FakeUnit(key="u1")
+        unit2 = FakeUnit(key="u2")
+        orch = FakeOrchestrator(
+            units=[unit1, unit2],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            budget_usd=10.0,
+        )
+        with patch("vastai_gpu_runner.batch.check_budget", return_value=False):
+            orch._deploy_phase()
+
+        assert unit1.status == "failed"
+        assert unit2.status == "failed"
+        assert "budget" in unit1.failure_reason
+        assert "budget" in unit2.failure_reason
+
+    def test_deploy_parallel_many_units(self) -> None:
+        units = [FakeUnit(key=f"u{i}") for i in range(5)]
+        orch = FakeOrchestrator(
+            units=units,
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            max_parallel_deploys=4,
+        )
+        orch._deploy_phase()
+
+        assert all(u.status == "deployed" for u in units)
+        assert len(orch._live_runners) == 5
+
+
+# ---------------------------------------------------------------------------
+# Poll phase: _check_unit
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUnit:
+    def test_r2_done_short_circuits_to_completed(self) -> None:
+        unit = FakeUnit(key="u1", done_in_r2=True, status="deployed")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "completed"
+        assert unit.status == "downloaded"
+        runner.check_progress.assert_not_called()
+        runner.destroy_instance.assert_called_once()
+
+    def test_ssh_complete_collects_results(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(return_value={"complete": True, "running": False})
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "completed"
+        assert unit.status == "downloaded"
+        assert "u1" in orch.collect_calls
+
+    def test_collect_failure_marks_unit_failed(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", collect_result=False)
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(return_value={"complete": True, "running": False})
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "failed"
+        assert unit.status == "failed"
+
+    def test_silent_worker_crash_triggers_instance_loss(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(
+            return_value={
+                "complete": False,
+                "running": False,
+                "worker_dead": True,
+            }
+        )
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "preempted"
+        assert unit.status == "pending"
+        assert unit.instance_id == ""
+        runner.destroy_instance.assert_called_once()
+
+    def test_silent_crash_but_r2_done_recovers(self) -> None:
+        """Worker dead + R2 DONE between checks → treat as completed."""
+        unit = FakeUnit(key="u1", status="deployed")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        # First R2 check: False. Second (after worker_dead): True.
+        r2_check_calls = [False, True]
+        orch.unit_is_done_in_r2 = lambda _u: r2_check_calls.pop(0)  # type: ignore[method-assign]
+        runner.check_progress = MagicMock(
+            return_value={"complete": False, "running": False, "worker_dead": True}
+        )
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "completed"
+        assert unit.status == "downloaded"
+
+    def test_running_keeps_unit_live(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(return_value={"running": True, "complete": False})
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "running"
+        assert unit.status == "deployed"
+        assert unit.key in orch._live_runners
+
+
+# ---------------------------------------------------------------------------
+# Retry cap
+# ---------------------------------------------------------------------------
+
+
+class TestRetryCap:
+    def test_retry_exhausted_marks_fatal(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", retry_count=2, instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            max_retries=2,
+        )
+        orch._live_runners[unit.key] = (
+            MagicMock(spec=CloudRunner),
+            CloudInstance(instance_id="i1"),
+            unit,
+        )
+
+        redeploy_ok = orch._handle_instance_loss(unit, unit.key, "crash")
+
+        assert redeploy_ok is False
+        assert unit.status == "failed"
+        assert "retries exhausted" in unit.failure_reason
+
+    def test_under_cap_allows_redeploy(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", retry_count=0, instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            max_retries=2,
+        )
+        orch._live_runners[unit.key] = (
+            MagicMock(spec=CloudRunner),
+            CloudInstance(instance_id="i1"),
+            unit,
+        )
+
+        redeploy_ok = orch._handle_instance_loss(unit, unit.key, "crash")
+
+        assert redeploy_ok is True
+        assert unit.status == "pending"
+        assert unit.retry_count == 1
+
+    def test_fatal_classification_skips_redeploy(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", retry_count=0)
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        orch._live_runners[unit.key] = (
+            MagicMock(spec=CloudRunner),
+            CloudInstance(instance_id="i1"),
+            unit,
+        )
+        orch.classify_failure = lambda u, e: "fatal"  # type: ignore[method-assign,return-value]
+
+        redeploy_ok = orch._handle_instance_loss(unit, unit.key, "bad input")
+
+        assert redeploy_ok is False
+        assert unit.status == "failed"
+        assert "fatal" in unit.failure_reason
+
+
+# ---------------------------------------------------------------------------
+# Resume from state
+# ---------------------------------------------------------------------------
+
+
+class TestResume:
+    def test_resume_reconnects_active_units(self) -> None:
+        unit = FakeUnit(
+            key="u1", status="running", instance_id="i1", ssh_host="1.2.3.4", ssh_port=22
+        )
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        orch._resume_from_state()
+
+        assert "u1" in orch._live_runners
+        _, instance, _ = orch._live_runners["u1"]
+        assert instance.instance_id == "i1"
+        assert unit.status == "running"  # unchanged
+
+    def test_resume_no_instance_id_skipped(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", instance_id="")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        orch._resume_from_state()
+        assert not orch._live_runners
+
+    def test_resume_reconstruct_failure_preempts(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+
+        def _boom(u: FakeUnit) -> CloudInstance:
+            raise RuntimeError("dead host")
+
+        orch.reconstruct_instance = _boom  # type: ignore[method-assign]
+        orch._resume_from_state()
+
+        assert unit.status == "pending"
+        assert "preempted" in unit.events
+
+
+# ---------------------------------------------------------------------------
+# Collect + cleanup phases
+# ---------------------------------------------------------------------------
+
+
+class TestCollectAndCleanup:
+    def test_collect_phase_r2_recovery(self) -> None:
+        unit = FakeUnit(key="u1", status="failed", done_in_r2=True)
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            r2_sink=MagicMock(),
+        )
+        orch._collect_phase()
+
+        assert unit.status == "downloaded"
+        assert "u1" in orch.collect_calls
+
+    def test_collect_phase_no_r2_sink_is_noop(self) -> None:
+        unit = FakeUnit(key="u1", status="failed", done_in_r2=True)
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            r2_sink=None,
+        )
+        orch._collect_phase()
+
+        assert unit.status == "failed"
+        assert orch.collect_calls == []
+
+    def test_cleanup_destroys_leftover_instances(self) -> None:
+        unit = FakeUnit(key="u1", status="deployed", instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        with patch("vastai_gpu_runner.batch.sweep_zombie_instances", return_value=0):
+            orch._cleanup_phase()
+
+        runner.destroy_instance.assert_called_once_with(instance)
+        assert not orch._live_runners
+
+
+# ---------------------------------------------------------------------------
+# Full run() lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRunLifecycle:
+    def test_run_happy_path_deploy_then_complete(self) -> None:
+        unit = FakeUnit(key="u1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(
+                deploy_result=_ok_deploy("i1"),
+                progress={"complete": True, "running": False},
+            ),
+            label_prefix="test-happy",
+            poll_interval_seconds=1,
+        )
+
+        with patch("vastai_gpu_runner.batch.sweep_zombie_instances", return_value=0):
+            orch.run()
+
+        assert unit.status == "downloaded"
+        assert "deployed" in unit.events
+        assert "completed" in unit.events
+
+    def test_run_no_pending_units_is_noop(self) -> None:
+        orch = FakeOrchestrator(
+            units=[],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test-empty",
+        )
+
+        with patch("vastai_gpu_runner.batch.sweep_zombie_instances", return_value=0):
+            orch.run()
+
+        assert not orch._live_runners
+
+    def test_run_deploy_failure_propagates_to_failed_state(self) -> None:
+        unit = FakeUnit(key="u1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_fail_deploy("boom")),
+            label_prefix="test-fail",
+        )
+
+        with patch("vastai_gpu_runner.batch.sweep_zombie_instances", return_value=0):
+            orch.run()
+
+        assert unit.status == "failed"
+        assert "boom" in unit.failure_reason
+
+
+# ---------------------------------------------------------------------------
+# Zombie sweep delegation
+# ---------------------------------------------------------------------------
+
+
+class TestZombieSweep:
+    def test_sweep_delegates_with_label_prefix(self) -> None:
+        orch = FakeOrchestrator(
+            units=[],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="oralamp-boltz2-abc",
+            r2_batch_id="batch-123",
+        )
+        with patch("vastai_gpu_runner.batch.sweep_zombie_instances", return_value=2) as mock_sweep:
+            killed = orch._sweep_zombies()
+
+        assert killed == 2
+        _, kwargs = mock_sweep.call_args
+        assert kwargs["label_prefix"] == "oralamp-boltz2-abc"
+        assert kwargs["r2_batch_id"] == "batch-123"
+
+    def test_sweep_failure_returns_zero(self) -> None:
+        orch = FakeOrchestrator(
+            units=[],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        with patch(
+            "vastai_gpu_runner.batch.sweep_zombie_instances",
+            side_effect=RuntimeError("api down"),
+        ):
+            killed = orch._sweep_zombies()
+        assert killed == 0
+
+
+# ---------------------------------------------------------------------------
+# Sanity: ABC cannot be instantiated
+# ---------------------------------------------------------------------------
+
+
+def test_abc_cannot_instantiate() -> None:
+    with pytest.raises(TypeError):
+        BatchOrchestrator(  # type: ignore[abstract]
+            runner_factory=lambda: CloudRunner(),
+            label_prefix="test",
+        )


### PR DESCRIPTION
## Summary

Introduces `BatchOrchestrator[UnitT]`, a template-method abstract base class one layer above `CloudRunner` that coordinates deploy → poll → collect → cleanup across many units in parallel. Generic over unit type so both shard-based (`ShardState`) and job-based (`JobState`) workloads share the same orchestration loop.

## Design

- **Consumer owns the batch state.** The ABC drives events (`on_unit_deployed`, `on_unit_failed`, `on_unit_completed`, `on_unit_preempted`); consumers update their own status strings and retry counters and persist via `save_state`. Decouples the orchestration loop from any specific `BatchState` schema.
- **Narrow domain hooks**: `iter_*` (state reads), `build_unit_payload` (files to upload), `reconstruct_instance` (resume), `collect_unit_results` (download), `unit_is_done_in_r2` (R2 DONE check), `classify_failure` (retryable vs fatal).
- **Concrete lifecycle inherited**: parallel `ThreadPoolExecutor` deploy, R2-first poll loop with exponential backoff (5s → 60s), 3-layer rescue on silent worker crash (re-check R2 before treating as preempted), `max_retries` cap enforcement, periodic zombie sweep via `orchestrator.sweep_zombie_instances`, budget check via `orchestrator.check_budget`, R2 recovery for failed-but-uploaded units in the collect phase, final cleanup destroy.
- **No provider coupling.** Talks to `CloudRunner` exclusively via a factory callback, so Vast.ai, RunPod, or a mock all plug in the same way.

## Tests (26 new, 106 total)

- Deploy phase: success, failure, R2 skip, budget-exceeded short-circuit, parallel many-unit deploy
- `_check_unit`: R2 DONE short-circuit, SSH complete, collect failure, silent worker crash, silent crash with R2 recovery, running state
- Retry cap: fatal after retries exhausted, under-cap redeploy eligibility, fatal classification override
- Resume: reconnect active units, skip units without instance_id, preempt on reconstruct failure
- Collect phase: R2 recovery, no-sink no-op
- Cleanup: destroys leftover instances
- Full `run()` lifecycle happy path, empty-units no-op, deploy-failure propagation
- Zombie sweep delegation with label prefix + R2 batch id
- ABC cannot be instantiated

## Complexity

All 19 new methods ≤10 (max `_poll_cycle_once` and `_poll_phase` at 5, `_deploy_phase` at 4). Commit history shows the two tightening passes:

1. `2652153` — initial split to ≤15
2. `ce76ffe` — further split to ≤10 under the qte77 baseline (after hardening PR #2 landed cap=10)

## Consumer migration path

`Boltz2CloudBatch` and `OpenMMCloudBatch` in OralBiome-AMP will subclass this ABC, deleting ~1800 lines of duplicated deploy/poll/recovery logic and eliminating two known drift bugs (MD missing `retry_count` cap; differing zombie sweep cadence).

Refs: ADR-003 (adopt vastai-gpu-runner), OralBiome-AMP ADR-002 stage 4.

## Test plan

- [x] `make validate` green end to end
- [x] 106 tests passing (80 existing + 26 new)
- [x] pyright strict clean
- [x] complexipy ≤10 clean
- [x] ruff extended ruleset clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)