### PR TITLE
feat(batch): add max_parallel_collects hook for parallel finalisation (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.3.0 (2026-04-15)
+
+### Added
+
+- `BatchOrchestrator(..., max_parallel_collects: int = 1)` — opt-in concurrent
+  finalisation of terminal units within a single poll cycle. Default preserves
+  sequential semantics. Set >1 when many units complete around the same
+  wall-clock time and the finalise step is I/O-bound (e.g. rsync over SSH).
+  Bandwidth-constrained environments should leave it at 1 or 2.
+- `BatchOrchestrator._classify_live_unit()` — pure classification half of the
+  poll cycle (R2 → SSH → worker_dead re-check), no side effects. Returns
+  `"terminal" | "running" | "preempted"`. The split makes `_poll_cycle_once`
+  safe to finalise terminal units in a thread pool.
+
+### Changed
+
+- `_poll_cycle_once` now classifies all live units first, then handles
+  preempted units serially, then finalises terminal units via
+  `_finalise_terminal_units` (optional parallel). `_check_unit` is retained
+  as a backwards-compat composition for single-unit callers and unit tests.
+- `BatchOrchestrator.__init__` rejects `max_parallel_collects < 1` with
+  `ValueError`.
+
+## 0.2.0 (2026-04-14)
+
+### Added
+
+- `BatchOrchestrator[UnitT]` — generic template-method ABC above `CloudRunner`
+  that coordinates many cloud GPU units in parallel. Handles resume, deploy,
+  zombie sweep, poll with exponential backoff, R2-first completion, silent
+  crash detection, retry cap, collect phase, cleanup. Consumers implement 14
+  narrow hooks over their own `BatchState` / `JobBatchState` type; bug fixes
+  land once and both shard-based and job-based workloads inherit them.
+- 26 unit tests covering deploy/poll/resume/retry/collect/cleanup/run lifecycle.
+
 ## 0.1.0 (2026-04-12)
 
 Initial extraction from [OralBiome-AMP](https://github.com/Lambda-Biolab/OralBiome-AMP).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vastai-gpu-runner"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cloud GPU orchestration framework for Vast.ai — batch deployment, R2 storage, worker lifecycle"
 requires-python = ">=3.11"
 authors = [{ name = "antomicblitz" }]
@@ -120,7 +120,7 @@ exclude_also = [
 
 # --- bump-my-version ---
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/src/vastai_gpu_runner/batch.py
+++ b/src/vastai_gpu_runner/batch.py
@@ -133,11 +133,24 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
         budget_usd: float = 0.0,
         max_retries: int = 2,
         max_parallel_deploys: int = 16,
+        max_parallel_collects: int = 1,
         poll_interval_seconds: int = 30,
         zombie_sweep_every_n_cycles: int = 5,
         poll_timeout_seconds: float = 0.0,
     ) -> None:
-        """Initialise orchestrator state. See class docstring for argument meanings."""
+        """Initialise orchestrator state. See class docstring for argument meanings.
+
+        ``max_parallel_collects`` controls how many terminal units are
+        finalised (``collect_unit_results`` + ``destroy_instance``)
+        concurrently within a single poll cycle. Default 1 preserves
+        sequential semantics. Raise it when many units complete around
+        the same wall-clock time and the download step is I/O-bound
+        (e.g. rsync over SSH); bandwidth-constrained environments should
+        leave it at 1 or 2.
+        """
+        if max_parallel_collects < 1:
+            msg = f"max_parallel_collects must be >= 1, got {max_parallel_collects}"
+            raise ValueError(msg)
         self._runner_factory = runner_factory
         self._label_prefix = label_prefix
         self._workspace_dir = workspace_dir
@@ -146,6 +159,7 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
         self._budget_usd = budget_usd
         self._max_retries = max_retries
         self._max_parallel_deploys = max_parallel_deploys
+        self._max_parallel_collects = max_parallel_collects
         self._poll_interval_seconds = poll_interval_seconds
         self._zombie_sweep_every_n_cycles = zombie_sweep_every_n_cycles
         self._poll_timeout_seconds = poll_timeout_seconds
@@ -407,32 +421,53 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
         return True
 
     def _poll_cycle_once(self) -> bool:
-        """One sweep over live units. Returns True if any unit made progress."""
-        any_progress = False
+        """One sweep over live units. Returns True if any unit made progress.
+
+        Phase A classifies each live unit (pure, no side effects). Phase B
+        handles preempted units (serial — destroy + instance-loss bookkeeping
+        is cheap). Phase C finalises terminal units, optionally in parallel
+        via ``max_parallel_collects``.
+        """
+        terminal: list[tuple[str, CloudRunner, CloudInstance, UnitT]] = []
+        preempted: list[tuple[str, CloudRunner, CloudInstance, UnitT]] = []
         for unit_key in list(self._live_runners.keys()):
             entry = self._live_runners.get(unit_key)
             if entry is None:
                 continue
             runner, instance, unit = entry
-            verdict = self._check_unit(runner, instance, unit)
-            if verdict in ("completed", "preempted"):
-                any_progress = True
-        return any_progress
+            verdict = self._classify_live_unit(runner, instance, unit)
+            if verdict == "terminal":
+                terminal.append((unit_key, runner, instance, unit))
+            elif verdict == "preempted":
+                preempted.append((unit_key, runner, instance, unit))
 
-    def _check_unit(
+        for unit_key, runner, instance, unit in preempted:
+            with contextlib.suppress(Exception):
+                runner.destroy_instance(instance)
+            with self._state_lock:
+                self._handle_instance_loss(unit, unit_key, "worker died silently")
+
+        if terminal:
+            self._finalise_terminal_units(terminal)
+
+        return bool(terminal or preempted)
+
+    def _classify_live_unit(
         self,
         runner: CloudRunner,
         instance: CloudInstance,
         unit: UnitT,
-    ) -> Literal["completed", "running", "preempted", "failed"]:
-        """Single-unit poll cycle. R2-first, then SSH fallback + rescue."""
-        unit_key = self.unit_key(unit)
+    ) -> Literal["terminal", "running", "preempted"]:
+        """Pure classification of a live unit. No side effects.
 
-        # Layer 1: R2 DONE marker (works even if SSH is flaky)
+        R2 DONE → ``terminal``. SSH ``complete`` → ``terminal``. SSH
+        ``worker_dead`` with R2 re-check miss → ``preempted``. Otherwise
+        ``running``. Exceptions from ``check_progress`` are logged and
+        classified as ``running`` (transient SSH flakiness).
+        """
         if self.unit_is_done_in_r2(unit):
-            return self._finalise_completed(runner, instance, unit, unit_key)
+            return "terminal"
 
-        # Layer 2: SSH progress check
         try:
             progress = runner.check_progress(instance)
         except Exception as exc:
@@ -444,26 +479,71 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
             return "running"
 
         if progress.get("complete"):
-            return self._finalise_completed(runner, instance, unit, unit_key)
+            return "terminal"
 
-        # Layer 3: silent worker crash detection
         if progress.get("worker_dead"):
             # Re-check R2 once more — worker may have uploaded results
             # between the check above and now.
             if self.unit_is_done_in_r2(unit):
-                return self._finalise_completed(runner, instance, unit, unit_key)
+                return "terminal"
             logger.warning(
                 "Poll %s: worker dead on %s — handling as instance loss",
                 self.unit_label(unit),
                 unit.instance_id,
             )
+            return "preempted"
+
+        return "running"
+
+    def _check_unit(
+        self,
+        runner: CloudRunner,
+        instance: CloudInstance,
+        unit: UnitT,
+    ) -> Literal["completed", "running", "preempted", "failed"]:
+        """Single-unit poll cycle. Composes ``_classify_live_unit`` + finalise.
+
+        Kept for backwards-compat with direct callers (unit tests, consumers
+        that prefer synchronous single-unit polling). The main loop uses
+        ``_poll_cycle_once`` which batches terminal units for parallel finalise.
+        """
+        unit_key = self.unit_key(unit)
+        verdict = self._classify_live_unit(runner, instance, unit)
+        if verdict == "running":
+            return "running"
+        if verdict == "preempted":
             with contextlib.suppress(Exception):
                 runner.destroy_instance(instance)
             with self._state_lock:
                 self._handle_instance_loss(unit, unit_key, "worker died silently")
             return "preempted"
+        return self._finalise_completed(runner, instance, unit, unit_key)
 
-        return "running"
+    def _finalise_terminal_units(
+        self,
+        terminal: list[tuple[str, CloudRunner, CloudInstance, UnitT]],
+    ) -> None:
+        """Finalise a batch of terminal units, optionally in parallel.
+
+        Each finalise does ``collect_unit_results`` (I/O-bound — the reason
+        we parallelise) then ``destroy_instance``. ``_finalise_completed``
+        already guards its state mutations with ``self._state_lock``, so
+        parallel execution is safe.
+        """
+        if self._max_parallel_collects <= 1 or len(terminal) == 1:
+            for unit_key, runner, instance, unit in terminal:
+                self._finalise_completed(runner, instance, unit, unit_key)
+            return
+
+        workers = min(self._max_parallel_collects, len(terminal))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(self._finalise_completed, runner, instance, unit, unit_key)
+                for unit_key, runner, instance, unit in terminal
+            ]
+            for fut in as_completed(futures):
+                with contextlib.suppress(Exception):
+                    fut.result()
 
     def _finalise_completed(
         self,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -640,6 +640,149 @@ class TestZombieSweep:
 
 
 # ---------------------------------------------------------------------------
+# Parallel collect (max_parallel_collects)
+# ---------------------------------------------------------------------------
+
+
+class TestParallelCollect:
+    """Tests for the ``max_parallel_collects`` constructor arg + split hooks.
+
+    The hook exists so consumers with slow I/O-bound finalise steps (e.g.
+    rsync over SSH) can opt into concurrent collection when many units
+    complete around the same wall-clock time. Default (1) preserves
+    sequential semantics; tests below pin both paths.
+    """
+
+    def test_default_is_one_sequential(self) -> None:
+        """Default constructor: max_parallel_collects == 1."""
+        orch = FakeOrchestrator(
+            units=[],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        assert orch._max_parallel_collects == 1
+
+    def test_invalid_value_raises(self) -> None:
+        """max_parallel_collects < 1 is rejected at construction."""
+        with pytest.raises(ValueError, match="max_parallel_collects"):
+            FakeOrchestrator(
+                units=[],
+                runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+                label_prefix="test",
+                max_parallel_collects=0,
+            )
+
+    def test_classify_live_unit_is_pure_no_side_effects(self) -> None:
+        """_classify_live_unit must not mutate state or call destroy_instance.
+
+        This is the contract that makes parallel finalise safe: the classify
+        half is pure, so we can batch multiple units' classifications before
+        touching any state.
+        """
+        unit = FakeUnit(key="u1", status="deployed")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(return_value={"complete": True, "running": False})
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._classify_live_unit(runner, instance, unit)
+
+        assert verdict == "terminal"
+        # No side effects: unit still "deployed", no collect called, no destroy.
+        assert unit.status == "deployed"
+        assert "u1" not in orch.collect_calls
+        runner.destroy_instance.assert_not_called()
+        assert unit.key in orch._live_runners
+
+    def test_classify_returns_preempted_without_destroying(self) -> None:
+        """Classify reports preempted but does NOT destroy — that's phase B."""
+        unit = FakeUnit(key="u1", status="deployed", instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(
+            return_value={"complete": False, "running": False, "worker_dead": True}
+        )
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        verdict = orch._classify_live_unit(runner, instance, unit)
+
+        assert verdict == "preempted"
+        runner.destroy_instance.assert_not_called()  # destroy is phase B, not classify
+        assert unit.status == "deployed"  # state mutation is phase B too
+
+    def test_poll_cycle_finalises_multiple_terminal_units_in_parallel(self) -> None:
+        """3 units, all terminal in one cycle, max_parallel_collects=3.
+
+        All 3 must be finalised, all 3 collect_calls recorded, all 3 status
+        == "downloaded", all 3 destroy_instance calls made, no units left in
+        live_runners.
+        """
+        units = [FakeUnit(key=f"u{i}", status="deployed") for i in range(3)]
+        orch = FakeOrchestrator(
+            units=units,
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            max_parallel_collects=3,
+        )
+        runners: list[MagicMock] = []
+        for u in units:
+            runner = MagicMock(spec=CloudRunner)
+            runner.check_progress = MagicMock(return_value={"complete": True, "running": False})
+            runner.destroy_instance = MagicMock(return_value=True)
+            instance = CloudInstance(instance_id=f"i-{u.key}")
+            orch._live_runners[u.key] = (runner, instance, u)
+            runners.append(runner)
+
+        any_progress = orch._poll_cycle_once()
+
+        assert any_progress is True
+        assert sorted(orch.collect_calls) == ["u0", "u1", "u2"]
+        assert all(u.status == "downloaded" for u in units)
+        for runner in runners:
+            runner.destroy_instance.assert_called_once()
+        assert not orch._live_runners  # all removed
+
+    def test_poll_cycle_sequential_when_max_parallel_is_one(self) -> None:
+        """max_parallel_collects=1 path: same 3 units, serial finalise.
+
+        Same observable outcome as the parallel path — the split doesn't
+        change semantics, only concurrency.
+        """
+        units = [FakeUnit(key=f"u{i}", status="deployed") for i in range(3)]
+        orch = FakeOrchestrator(
+            units=units,
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+            max_parallel_collects=1,
+        )
+        for u in units:
+            runner = MagicMock(spec=CloudRunner)
+            runner.check_progress = MagicMock(return_value={"complete": True, "running": False})
+            runner.destroy_instance = MagicMock(return_value=True)
+            instance = CloudInstance(instance_id=f"i-{u.key}")
+            orch._live_runners[u.key] = (runner, instance, u)
+
+        any_progress = orch._poll_cycle_once()
+
+        assert any_progress is True
+        assert orch.collect_calls == ["u0", "u1", "u2"]  # strict order
+        assert all(u.status == "downloaded" for u in units)
+        assert not orch._live_runners
+
+
+# ---------------------------------------------------------------------------
 # Sanity: ABC cannot be instantiated
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -939,7 +939,7 @@ wheels = [
 
 [[package]]
 name = "vastai-gpu-runner"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Split `_check_unit` into a pure classifier `_classify_live_unit` + backwards-compat composition; rewrite `_poll_cycle_once` to batch terminal units and finalise them via a new `_finalise_terminal_units` helper with an optional `ThreadPoolExecutor`
- Expose the hook as `BatchOrchestrator(..., max_parallel_collects: int = 1)` — default preserves sequential semantics; set higher when many units complete around the same wall-clock time and finalise is I/O-bound (e.g. rsync over SSH)
- Bump version 0.2.0 → 0.3.0, add CHANGELOG entries for 0.2.0 (backfill) and 0.3.0

## Motivation

OralBiome-AMP's Boltz-2 port (task #9 of ADR-002 stage 4 phase 2) is about to inherit the ABC, but its current inline orchestrator parallelises rsync across 8 shards via a `ThreadPoolExecutor`. Moving to the ABC as-is would sequentialise those downloads, adding ~3.5 min to every batch. Rather than duplicate the parallel-finalise logic in each consumer (OralBiome-AMP, and task #10's OpenMM orchestrator right after), the hook lives here so both consumers inherit it.

Contract:
- `_classify_live_unit` is **pure** — no side effects, no `destroy_instance`, no state mutation. Tested in `TestParallelCollect::test_classify_live_unit_is_pure_no_side_effects`.
- Preempted units are always handled **serially** in phase B of `_poll_cycle_once`. Destroy + `_handle_instance_loss` is cheap and serialising keeps the state-lock section predictable.
- Terminal units go through `_finalise_terminal_units`, which falls back to sequential when `max_parallel_collects == 1` or when there's only one terminal unit. `_finalise_completed` already guards state mutations with `self._state_lock`, so parallel execution is thread-safe against consumer `save_state` / `on_unit_completed` callbacks.
- `max_parallel_collects < 1` raises `ValueError` at construction.

## Test plan

- [x] 26 existing tests in `TestDeployPhase` / `TestCheckUnit` / `TestRetryCap` / `TestResume` / `TestCollectAndCleanup` / `TestRunLifecycle` / `TestZombieSweep` unchanged and still green — proves the split preserved behaviour
- [x] 6 new tests in `TestParallelCollect`:
  - `test_default_is_one_sequential` — constructor default
  - `test_invalid_value_raises` — validation
  - `test_classify_live_unit_is_pure_no_side_effects` — classify purity
  - `test_classify_returns_preempted_without_destroying` — classify purity under preemption
  - `test_poll_cycle_finalises_multiple_terminal_units_in_parallel` — 3 units, `max_parallel_collects=3`, all finalised
  - `test_poll_cycle_sequential_when_max_parallel_is_one` — same 3 units, serial path, identical outcome
- [x] 112 total tests pass, complexipy clean, ruff + pyright clean via `make validate`
- [ ] OralBiome-AMP pin bump + Boltz-2 port smoke baseline diff (task #9, separate PR in consumer repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)