### PR TITLE
feat(batch): capture worker.log before destroying preempted instance

### DIFF
--- a/src/vastai_gpu_runner/batch.py
+++ b/src/vastai_gpu_runner/batch.py
@@ -68,13 +68,12 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import TYPE_CHECKING, Generic, Literal, Protocol, TypeVar
 
 from vastai_gpu_runner.orchestrator import check_budget, sweep_zombie_instances
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from vastai_gpu_runner.runner import CloudRunner
     from vastai_gpu_runner.storage.r2 import R2Sink
     from vastai_gpu_runner.types import CloudInstance
@@ -218,6 +217,73 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
     @abstractmethod
     def classify_failure(self, unit: UnitT, error: str) -> FailureVerdict:
         """Classify a failure as retryable or fatal."""
+
+    # -- Optional hooks (default-implemented, override when needed) --------
+
+    def capture_preempt_diagnostics(
+        self,
+        runner: CloudRunner,
+        instance: CloudInstance,
+        unit: UnitT,
+    ) -> None:
+        """Persist ``worker.log`` (and tail context) before the instance is destroyed.
+
+        Called from the preempted path on every silent worker death so the
+        next debugging session has real evidence instead of the single
+        "worker died silently" log line. The default implementation
+        SSH-cats ``{workspace}/worker.log`` and a short ``dmesg -T``
+        tail into
+        ``batch_diagnostics/{unit_key}_{instance_id}_{timestamp}.log``
+        under the current working directory. Subclasses can override to
+        redirect the capture into domain-specific paths (e.g. a
+        per-target results dir).
+
+        Swallows every exception — a diagnostic capture MUST NEVER
+        block destroy, because a leaked instance keeps burning dollars.
+        """
+        from vastai_gpu_runner.ssh import ssh_cmd
+
+        _ = runner  # reserved for subclass overrides that need runner state
+        try:
+            diag_dir = Path.cwd() / "batch_diagnostics"
+            diag_dir.mkdir(parents=True, exist_ok=True)
+            timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+            unit_key = self.unit_key(unit)
+            iid = instance.instance_id or "unknown"
+            out_path = diag_dir / f"{unit_key}_{iid}_{timestamp}.log"
+
+            sections: list[str] = [
+                f"# preempt diagnostics for {self.unit_label(unit)}",
+                f"# instance_id: {iid}",
+                f"# ssh: {instance.ssh_user}@{instance.ssh_host}:{instance.ssh_port}",
+                f"# workspace: {self._workspace_dir}",
+                f"# captured_at: {timestamp}",
+                "",
+                "## worker.log (full) ##",
+            ]
+            rc, worker_log = ssh_cmd(instance, f"cat {self._workspace_dir}/worker.log", timeout=20)
+            sections.append(worker_log if rc == 0 else f"[ssh rc={rc}] {worker_log}")
+            sections.extend(("", "## worker.exitcode ##"))
+            rc2, exitcode = ssh_cmd(
+                instance, f"cat {self._workspace_dir}/worker.exitcode 2>/dev/null", timeout=10
+            )
+            sections.append(exitcode if rc2 == 0 else f"[ssh rc={rc2}] {exitcode}")
+            sections.extend(("", "## dmesg tail ##"))
+            rc3, dmesg = ssh_cmd(instance, "dmesg -T 2>&1 | tail -40", timeout=10)
+            sections.append(dmesg if rc3 == 0 else f"[ssh rc={rc3}] {dmesg}")
+
+            out_path.write_text("\n".join(sections) + "\n")
+            logger.info(
+                "Captured preempt diagnostics for %s → %s",
+                self.unit_label(unit),
+                out_path,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to capture preempt diagnostics for %s: %s",
+                self.unit_label(unit),
+                exc,
+            )
 
     # -- State-mutation events (subclasses override) -----------------------
 
@@ -443,6 +509,8 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
 
         for unit_key, runner, instance, unit in preempted:
             with contextlib.suppress(Exception):
+                self.capture_preempt_diagnostics(runner, instance, unit)
+            with contextlib.suppress(Exception):
                 runner.destroy_instance(instance)
             with self._state_lock:
                 self._handle_instance_loss(unit, unit_key, "worker died silently")
@@ -512,6 +580,8 @@ class BatchOrchestrator(ABC, Generic[UnitT]):
         if verdict == "running":
             return "running"
         if verdict == "preempted":
+            with contextlib.suppress(Exception):
+                self.capture_preempt_diagnostics(runner, instance, unit)
             with contextlib.suppress(Exception):
                 runner.destroy_instance(instance)
             with self._state_lock:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -385,6 +385,143 @@ class TestCheckUnit:
 
 
 # ---------------------------------------------------------------------------
+# capture_preempt_diagnostics — silent worker crash forensics (#164)
+#
+# Before the fix: a "worker died silently" verdict fired destroy_instance
+# without any log capture, so the orchestrator only recorded the single
+# "worker died silently" log line. 3 of 5 instances in a 2026-04-20 MD
+# batch crashed this way ~60-180 s after Deploy success, and there was
+# no diagnostic trail to investigate why. After the fix: the default
+# implementation pulls /workspace/worker.log (+ worker.exitcode +
+# dmesg tail) via SSH and writes it to
+# batch_diagnostics/{unit}_{instance}_{timestamp}.log before destroy.
+# A raise inside the capture must not block destroy — leaked instances
+# keep burning dollars.
+# ---------------------------------------------------------------------------
+
+
+class TestCapturePreemptDiagnostics:
+    """Preempted path captures worker.log before destroy, swallows errors."""
+
+    @staticmethod
+    def _preempted_poll() -> dict[str, object]:
+        return {"complete": False, "running": False, "worker_dead": True}
+
+    def _orch_with_preempted_unit(
+        self,
+    ) -> tuple[FakeOrchestrator, CloudRunner, CloudInstance, FakeUnit]:
+        unit = FakeUnit(key="u1", status="deployed", instance_id="i1")
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(return_value=self._preempted_poll())
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(
+            instance_id="i1",
+            ssh_host="1.2.3.4",
+            ssh_port=22,
+            ssh_user="root",
+        )
+        orch._live_runners[unit.key] = (runner, instance, unit)
+        return orch, runner, instance, unit
+
+    def test_capture_called_before_destroy_on_preempted(self) -> None:
+        """capture_preempt_diagnostics fires before destroy_instance."""
+        orch, runner, instance, unit = self._orch_with_preempted_unit()
+
+        call_order: list[str] = []
+        orch.capture_preempt_diagnostics = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda *_a, **_k: call_order.append("capture")
+        )
+        runner.destroy_instance = MagicMock(
+            side_effect=lambda *_a, **_k: call_order.append("destroy")
+        )
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "preempted"
+        assert call_order == ["capture", "destroy"]
+        orch.capture_preempt_diagnostics.assert_called_once_with(runner, instance, unit)
+
+    def test_capture_exception_does_not_block_destroy(self) -> None:
+        """A raising capture must not prevent the instance from being destroyed."""
+        orch, runner, instance, unit = self._orch_with_preempted_unit()
+        orch.capture_preempt_diagnostics = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("SSH network is on fire")
+        )
+
+        verdict = orch._check_unit(runner, instance, unit)
+
+        assert verdict == "preempted"
+        runner.destroy_instance.assert_called_once()
+        assert unit.status == "pending"  # instance-loss bookkeeping still happened
+
+    def test_default_capture_writes_diagnostics_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default implementation SSH-cats worker.log into batch_diagnostics/."""
+        orch, runner, instance, unit = self._orch_with_preempted_unit()
+        monkeypatch.chdir(tmp_path)
+
+        def fake_ssh(_instance: CloudInstance, cmd: str, *, timeout: int = 30) -> tuple[int, str]:
+            del timeout
+            if "worker.log" in cmd and "exitcode" not in cmd:
+                return 0, "Starting production\nCUDA error: driver initialization failed\n"
+            if "worker.exitcode" in cmd:
+                return 0, "1"
+            if "dmesg" in cmd:
+                return 0, "[12345.678] nvidia-smi: GPU has fallen off the bus"
+            return 1, ""
+
+        with patch("vastai_gpu_runner.ssh.ssh_cmd", side_effect=fake_ssh):
+            orch._check_unit(runner, instance, unit)
+
+        diag_dir = tmp_path / "batch_diagnostics"
+        assert diag_dir.is_dir()
+        logs = list(diag_dir.glob("u1_i1_*.log"))
+        assert len(logs) == 1
+        content = logs[0].read_text()
+        assert "worker.log" in content
+        assert "CUDA error" in content
+        assert "exitcode" in content
+        assert "GPU has fallen off the bus" in content
+
+    def test_successful_completion_does_not_capture(self) -> None:
+        """Happy path (complete=True) must never trigger diagnostic capture."""
+        unit = FakeUnit(key="u1", status="deployed", instance_id="i1", collect_result=True)
+        orch = FakeOrchestrator(
+            units=[unit],
+            runner_factory=_mock_runner_factory(deploy_result=_ok_deploy()),
+            label_prefix="test",
+        )
+        orch.capture_preempt_diagnostics = MagicMock()  # type: ignore[method-assign]
+        runner = MagicMock(spec=CloudRunner)
+        runner.check_progress = MagicMock(return_value={"complete": True, "running": False})
+        runner.destroy_instance = MagicMock(return_value=True)
+        instance = CloudInstance(instance_id="i1")
+        orch._live_runners[unit.key] = (runner, instance, unit)
+
+        orch._check_unit(runner, instance, unit)
+
+        orch.capture_preempt_diagnostics.assert_not_called()
+
+    def test_poll_cycle_once_also_captures_on_preempted(self) -> None:
+        """The parallel-poll path (``_poll_cycle_once``) must also capture."""
+        orch, runner, instance, unit = self._orch_with_preempted_unit()
+        orch.capture_preempt_diagnostics = MagicMock()  # type: ignore[method-assign]
+
+        orch._poll_cycle_once()
+
+        orch.capture_preempt_diagnostics.assert_called_once_with(runner, instance, unit)
+        runner.destroy_instance.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Retry cap
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add ``BatchOrchestrator.capture_preempt_diagnostics(runner, instance, unit)`` — a default-implemented hook called **before** ``destroy_instance`` on every "worker died silently" verdict.
- Default pulls ``{workspace_dir}/worker.log`` (full), ``{workspace_dir}/worker.exitcode``, and a ``dmesg -T | tail -40`` via SSH and writes them to ``batch_diagnostics/{unit_key}_{instance_id}_{timestamp}.log`` under the current working directory. Subclasses can override to route the capture to domain-specific paths (e.g. a per-target results dir in OralBiome-AMP).
- Called from both preempted code paths: ``_poll_cycle_once`` and ``_check_unit``. Each SSH call has a bounded timeout (20 s / 10 s / 10 s); every step is wrapped in ``contextlib.suppress(Exception)`` so a failed capture never blocks destroy — a leaked cloud instance keeps burning dollars.

## Why
OralBiome-AMP#164. On a recent MD batch 3 of 5 cloud instances crashed ~60–180 s after ``Deploy success`` and the only forensic evidence the orchestrator preserved was the single log line ``worker died silently``. ``destroy_instance`` had already wiped the filesystem. Without ``worker.log`` we can't tell whether it was a CUDA driver crash, OpenMM exception, OOM kill, or a Vast.ai host reboot. This hook preserves exactly that log (plus ``worker.exitcode`` and a ``dmesg`` tail for host-side hangs) before the container goes away.

## Test plan
- [x] ``uv run pytest tests/`` → 198 passed (5 new + 193 existing).
- [x] ``TestCapturePreemptDiagnostics`` pins: capture fires before destroy, exceptions are swallowed, happy path never captures, ``_poll_cycle_once`` also captures, default implementation actually writes the expected file with the three sections.
- [x] ``ruff check`` / ``ruff format --check`` / ``pyright --strict`` (src only) clean.
- [ ] OralBiome-AMP pin bump (separate PR) — no code change required on the consumer side; the default implementation works out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)