### PR TITLE
docs: add vision, roadmap, user stories, and architecture-v2

### DIFF
--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -1,0 +1,169 @@
+# Architecture v2 (target)
+
+This doc describes the **target architecture** after roadmap items 1–3 land. For the current-state architecture (today's code) see `architecture.md`. For scope and sequencing see `roadmap.md`.
+
+## What changes vs v1
+
+In one paragraph: `CloudRunner` stays as the single ABC for SSH-lifecycle providers and gains two siblings — `LocalRunner` (subprocess) and `RunPodRunner`. A new `vastai_gpu_runner.inference` module appears alongside `storage/` as a worker-side capability, not a runner. Serverless-GPU providers (Modal, Beam, Replicate) are explicitly out of scope for `CloudRunner` and flagged as needing a second ABC — deferred.
+
+Diff vs v1:
+
+- **+** `providers/local.py` (`LocalRunner`)
+- **+** `providers/runpod.py` (`RunPodRunner`)
+- **+** `inference/` package (`client.py`, `providers.py`)
+- **+** `Provider.LOCAL`, `Provider.RUNPOD` enum members
+- **~** `cli.py check` iterates configured providers instead of assuming Vast.ai
+- **—** No changes to `runner.py` ABC signature
+- **—** No changes to `state.py`, `batch.py`, `storage/r2.py`, `worker/base.py`
+
+## Provider taxonomy
+
+Three lanes. Only Lane A is served by `CloudRunner`.
+
+### Lane A — SSH-lifecycle providers
+
+Full `CloudRunner` ABC implementation. Lifecycle: search → create → wait → deploy → launch → poll → download → destroy.
+
+| Provider | Module | Status |
+|---|---|---|
+| Vast.ai | `providers/vastai.py` | Shipped |
+| Local (subprocess) | `providers/local.py` | Roadmap item 1 |
+| RunPod | `providers/runpod.py` | Roadmap item 2 |
+| TensorDock / Lambda Labs / CoreWeave / Crusoe / Paperspace | — | Deferred |
+
+### Lane B — Serverless-GPU providers (deferred)
+
+Providers whose primitive is "invoke a function on a GPU", not "provision a VM". Examples: Modal, Beam.cloud, Replicate, Baseten, Fal.ai.
+
+The `CloudRunner` lifecycle does not map: there is no SSH, no `create_instance`, no `destroy_instance` — instead there is `deploy function → call function → receive result`. Shoehorning them into `CloudRunner` would either degrade the abstraction or introduce no-op methods that hide real lifecycle differences.
+
+**Decision**: a second ABC (provisionally `ServerlessRunner`) is the right answer. **Deferred** until a concrete user asks for it.
+
+### Lane C — Inference APIs
+
+Not runners. HTTP endpoints that serve models: Groq, Cerebras, OpenRouter (committed); HuggingFace, NVIDIA NIM, Fireworks, Together, DeepInfra, Novita, Lepton, GitHub Models (deferred).
+
+Lives in `vastai_gpu_runner.inference` and is **imported by workers**, not orchestrated by the framework. The framework never calls inference on the user's behalf.
+
+## Layered design (v2)
+
+```
+┌─────────────────────────────────────────────────┐
+│  CLI (cli.py)                                   │  User-facing commands
+├─────────────────────────────────────────────────┤
+│  BatchOrchestrator (batch.py)                   │  Deploy/poll/collect many units
+├─────────────────────────────────────────────────┤
+│  Orchestrator utils (orchestrator.py)           │  Zombie sweep, detach, budget
+├─────────────────────────────────────────────────┤
+│  CloudRunner (runner.py) ── Lane A ABC          │  Provider-agnostic lifecycle
+├──────────────┬──────────────┬───────────────────┤
+│ VastaiRunner │ RunPodRunner │ LocalRunner       │  Lane A implementations
+├──────────────┴──────────────┴───────────────────┤
+│  SSH (ssh.py)      — used by Vast.ai, RunPod    │
+│  subprocess        — used by Local              │
+├─────────────────────────────────────────────────┤
+│  Workers (worker/base.py)                       │  GPU-side execution
+│    └── imports inference/ (Lane C, optional)    │
+├─────────────────────────────────────────────────┤
+│  Storage (storage/r2.py)                        │  Result persistence
+├─────────────────────────────────────────────────┤
+│  State (state.py)                               │  Crash recovery
+└─────────────────────────────────────────────────┘
+
+Lane B (ServerlessRunner ABC) — deferred, not drawn.
+```
+
+## `LocalRunner` shape
+
+Each ABC method's local-subprocess override. All run on the host; no SSH, no network.
+
+| ABC method | `LocalRunner` behavior |
+|---|---|
+| `search_offers` | Return `[{"machine_id": "local", "dph_total": 0.0}]` (single synthetic offer, price 0) |
+| `create_instance` | Return `CloudInstance(provider=Provider.LOCAL, instance_id="local", ssh_host="localhost", ...)`; allocate a tempdir workspace |
+| `wait_for_boot` | Return `True` immediately |
+| `verify_gpu` | `subprocess.run(["nvidia-smi"])`; log and return `True` on failure (CI-friendly) |
+| `deploy_files` | `shutil.copy` each source into the tempdir workspace |
+| `setup_environment` | Return `True` (no-op) |
+| `launch_worker` | `subprocess.Popen(["bash", "worker.sh"], cwd=workspace)`; persist PID |
+| `check_progress` | Poll PID liveness + presence of a `DONE` marker in the workspace |
+| `list_remote_files` | `os.listdir(workspace)` |
+| `download_file` | `shutil.copy(workspace/name, local_path)` |
+| `destroy_instance` | Kill process if alive; remove workspace; return `True` |
+| `capture_deploy_failure_diagnostics` | Inherited no-op (nothing to capture) |
+
+The `CloudInstance.ssh_host`/`ssh_port`/`ssh_user` fields remain at defaults; nothing in `LocalRunner` invokes `ssh.py`. No ABC change.
+
+## `RunPodRunner` shape
+
+Each ABC method's RunPod backing call.
+
+| ABC method | `RunPodRunner` behavior |
+|---|---|
+| `search_offers` | Query RunPod GPU-types endpoint; filter by `gpu_model` and `max_cost_per_hour` |
+| `create_instance` | POST to pods endpoint with Docker image, env, GPU type; return `CloudInstance` with returned SSH host/port |
+| `wait_for_boot` | Poll pod status until `RUNNING`, then retry SSH until responsive (reuse existing `ssh.py` pattern) |
+| `verify_gpu` | `ssh_cmd(nvidia-smi)` via `ssh.py` |
+| `deploy_files` | `scp_upload` from `ssh.py` |
+| `setup_environment` | Optional image-specific setup (same hook Vast.ai uses) |
+| `launch_worker` | `ssh_cmd("bash worker.sh &")` |
+| `check_progress` | R2-first poll, SSH fallback (mirror `VastaiRunner`) |
+| `list_remote_files` | `ssh_cmd("ls /workspace")` |
+| `download_file` | `scp_download` |
+| `destroy_instance` | Belt-and-suspenders: stop endpoint → terminate endpoint → verify → re-terminate if resurrected. Apply `allowed_images` ownership guard. |
+| `capture_deploy_failure_diagnostics` | Fetch pod logs via API; attach to failure record |
+
+Credentials: `RUNPOD_API_KEY` env var or `~/.cloud-credentials`. Image whitelist (`allowed_images`) is ported verbatim from `VastaiRunner`.
+
+## Inference module shape
+
+```
+inference/
+    __init__.py          # Re-exports InferenceClient, InferenceProvider
+    providers.py         # Enum + base URL + auth env var per provider
+    client.py            # Thin OpenAI SDK wrapper
+```
+
+Minimal public surface:
+
+```python
+from vastai_gpu_runner.inference import InferenceClient, InferenceProvider
+
+client = InferenceClient(provider=InferenceProvider.GROQ)
+reply = client.chat(
+    messages=[{"role": "user", "content": "hello"}],
+    model="llama-3.3-70b-versatile",
+)
+```
+
+Under the hood, each provider entry is `(base_url, auth_env_var)`. Adding a new OpenAI-compatible provider is one line. Non-OpenAI-compatible providers (Replicate, Fal.ai) are out of scope.
+
+Credentials: env var first, `~/.cloud-credentials` second. Same precedence as Vast.ai and R2.
+
+OpenAI SDK is an optional extra: `uv add "vastai-gpu-runner[inference]"`.
+
+## ABC changes required
+
+**None for Lanes A and C.** The research pass confirmed the existing `CloudRunner` ABC hosts `LocalRunner` and `RunPodRunner` without modification. `capture_deploy_failure_diagnostics` is already an optional override. `search_offers` already defaults to `[]`. `destroy_instance` can return `True` for trivially destroyable backends.
+
+Lane B (serverless) is the only case requiring a second ABC. That ABC is **not designed here** — this doc deliberately leaves it unspecified until a concrete need appears.
+
+## Open questions
+
+These are flagged here for resolution as roadmap items land. They are **not** blocking for items 1–3.
+
+### Credentials unification
+
+Vast.ai uses its own CLI config; R2 uses `~/.cloud-credentials`; RunPod will want `RUNPOD_API_KEY`; inference providers want their own keys. A single loader (env-var-first, file-second, per-provider namespace) would be cleaner than each subclass re-inventing it. Design deferred until item 2 lands and we have a concrete second case.
+
+### Cost reporting across providers
+
+The estimator today queries Vast.ai's live marketplace. A multi-provider estimator needs a pluggable pricing interface. Not blocking — the estimator can remain Vast.ai-specific until a user asks to compare.
+
+### Test matrix
+
+How many providers must pass the ABC contract test? Starting answer: all Lane A providers run an identical happy-path test against a recorded fixture, plus each has its own provider-specific integration test gated on credentials.
+
+### Package rename
+
+With `LocalRunner` and `RunPodRunner` in-tree, the package name `vastai-gpu-runner` becomes slightly misleading. Not renaming now — rename churn is expensive and the name is load-bearing for existing users. Revisit after item 2 ships.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,131 @@
+# Roadmap
+
+**Scope**: committed near-term work only. Deferred items are listed once at the bottom with a single-line reason each. See `vision.md` for horizon framing and `architecture-v2.md` for the target architecture.
+
+## Committed items
+
+| # | Item | Rationale |
+|---|---|---|
+| 1 | `LocalRunner` (subprocess MVP) | Zero-cost CI + dev loop; proves `CloudRunner` ABC is genuinely provider-agnostic |
+| 2 | `RunPodRunner` | Second cloud backend; closest Vast.ai analogue (SSH + Docker + spot + per-second) |
+| 3 | `vastai_gpu_runner.inference` helper | OpenAI-compatible client (Groq / Cerebras / OpenRouter) callable from inside workers |
+
+Order is prescriptive: item 1 first (no external dependency, validates ABC), then item 2 (second provider, proves portability), then item 3 (orthogonal, worker-side capability).
+
+---
+
+## Item 1 — `LocalRunner`
+
+### Scope
+
+- New module `vastai_gpu_runner/providers/local.py`
+- Subclass of `CloudRunner` that executes the full lifecycle on the host via `subprocess`
+- `search_offers` returns a synthetic single offer `{"machine_id": "local"}`
+- `create_instance` returns a `CloudInstance(provider=Provider.LOCAL, ssh_host="localhost", ...)` (fields kept as defaults; no SSH is actually used)
+- `deploy_files` uses `shutil.copy` into a tempdir workspace
+- `launch_worker` uses `subprocess.Popen(["bash", "worker.sh"], cwd=workspace)`
+- `check_progress` polls PID liveness and a local `DONE` marker file
+- `destroy_instance` is a no-op returning `True`
+- New `Provider.LOCAL` enum member in `types.py`
+
+### Exit criteria
+
+- End-to-end run of an existing worker against `LocalRunner` with no cloud credentials present
+- Pytest suite covering each overridden method
+- One worked example in `docs/extending.md` or `docs/guide.md` showing a local dry run
+- No changes required to the `CloudRunner` ABC
+
+### Out of scope
+
+- GPU passthrough (works if host has NVIDIA + CUDA, otherwise silently CPU)
+- Docker-based variant (deferred — see below)
+- Concurrency / multi-worker-per-host (single job at a time)
+
+### Dependencies
+
+None. Does not block or depend on items 2 or 3.
+
+---
+
+## Item 2 — `RunPodRunner`
+
+### Scope
+
+- New module `vastai_gpu_runner/providers/runpod.py`
+- Subclass of `CloudRunner` backed by the RunPod REST/SDK API
+- Offer search via RunPod's GPU type/price query
+- Instance creation via their pods endpoint; SSH via returned host+port
+- File deployment reuses existing `ssh.py` (`scp_upload` / `scp_download`)
+- Destroy uses RunPod's stop + terminate endpoints, mirroring Vast.ai's belt-and-suspenders pattern
+- New `Provider.RUNPOD` enum member
+- Credentials: `RUNPOD_API_KEY` env var + `~/.cloud-credentials` entry
+
+### Exit criteria
+
+- Feature parity with `VastaiRunner` for the core lifecycle
+- Ownership guard ported (refuse to destroy pods running images outside `allowed_images`)
+- Pytest suite with REST responses mocked
+- One smoke-test run against a real RunPod account
+- CLI command `vastai-gpu-runner check` reports RunPod credentials alongside Vast.ai + R2
+
+### Out of scope
+
+- RunPod serverless endpoints (they require a different lifecycle — deferred)
+- Network volumes / persistent storage (R2 remains the result sink)
+- CLI rename (the CLI remains `vastai-gpu-runner` for now; see open questions in `architecture-v2.md`)
+
+### Dependencies
+
+Should land **after** item 1. `LocalRunner` is the cheapest way to verify new ABC edge cases surface by adding a second backend.
+
+---
+
+## Item 3 — `vastai_gpu_runner.inference` helper
+
+### Scope
+
+- New package `vastai_gpu_runner/inference/`
+- `client.py` — thin wrapper around the OpenAI SDK pointed at any OpenAI-compatible endpoint
+- `providers.py` — enum + base URL + auth-env-var map for Groq, Cerebras, OpenRouter
+- Public surface: `InferenceClient(provider=InferenceProvider.GROQ).chat(messages, model=...)`
+- Importable from *inside* a `BaseWorker` — not orchestrated by `CloudRunner`
+- Credentials read from env vars (`GROQ_API_KEY`, `CEREBRAS_API_KEY`, `OPENROUTER_API_KEY`) or `~/.cloud-credentials`
+- Optional: embeddings method for providers that support it (OpenRouter, DeepInfra)
+
+### Exit criteria
+
+- Worked example in `docs/extending.md`: a worker that calls Groq instead of running a local model
+- Pytest suite with mocked HTTP responses
+- Providers list documented in `api.md`
+- No new non-optional dependency (OpenAI SDK added as `[inference]` extra)
+
+### Out of scope
+
+- Streaming responses (add when a consumer needs it)
+- Model catalog / routing logic (OpenRouter already does this)
+- Non-OpenAI-compatible providers (Replicate, Fal.ai) — deferred
+- Orchestration side (the framework does not call inference on the user's behalf)
+
+### Dependencies
+
+None. Orthogonal to items 1 and 2. Can land in parallel.
+
+---
+
+## Deferred (documented, not committed)
+
+Items explored during provider research, not scheduled. Revisit when a user need surfaces.
+
+| Item | Reason for deferral |
+|---|---|
+| `TensorDockRunner` | Viable (marketplace + SSH), but RunPod covers the need until demand surfaces for a second spot-priced backend |
+| `LambdaLabsRunner` | Premium/reliable but no spot instances; revisit when an H100/B200 use case lands |
+| `CoreWeaveRunner` | Enterprise-gated onboarding; not self-serve |
+| `CrusoeRunner` | Smaller ecosystem; revisit after RunPod validates the ABC |
+| `PaperspaceRunner` | Limited regions; acceptable but lower priority than RunPod |
+| Docker-based `LocalRunner` | Subprocess variant covers 90% of CI/dev need; Docker adds container-contract parity but also daemon + toolkit friction |
+| e2b / Daytona sandbox backend | CPU-only preflight use case is largely absorbed by `LocalRunner` |
+| Serverless-GPU providers (Modal, Beam, Replicate, Baseten, Fal.ai) | Lifecycle does not map onto `CloudRunner`; requires a second ABC (see `architecture-v2.md` Lane B) |
+| HuggingFace Inference Endpoints | Covered transitively via HF routing; dedicated wrapper deferred |
+| NVIDIA NIM (`build.nvidia.com`) | Enterprise pricing model unclear for self-serve users; deferred until a user need is concrete |
+| GitHub Models | Thin-wrapper value low; OpenRouter covers the same breadth |

--- a/docs/userstories.md
+++ b/docs/userstories.md
@@ -1,0 +1,52 @@
+# User stories
+
+Three personas drive the near-term roadmap. Each story uses `As a <persona>, I want <capability> so that <outcome>` and is tagged with the roadmap item it maps to — `[R1]` `LocalRunner`, `[R2]` `RunPodRunner`, `[R3]` inference helper, `[future]` deferred.
+
+See `roadmap.md` for item scope and `vision.md` for non-goals.
+
+## Persona 1 — Batch-ML researcher (end user)
+
+Runs workloads on rented GPUs. Cares about cost, crash recovery, and getting results into R2 without babysitting. Does not want to know which cloud is cheapest this week — wants the framework to choose.
+
+- As a researcher, I want to switch my batch from Vast.ai to RunPod by changing one import so that I can follow availability and price without rewriting workers. `[R2]`
+- As a researcher, I want `vastai-gpu-runner check` to verify *all* configured providers' credentials so that I know before launch which backends are usable. `[R2]`
+- As a researcher, I want cost estimates to work across providers so that I can compare before committing. `[future]`
+- As a researcher, I want my worker to call a hosted LLM (Groq, Cerebras) via a single import so that I don't provision a GPU for an LLM call. `[R3]`
+- As a researcher, I want to keep my existing `BatchState` and R2 results format when I change provider so that historical runs remain comparable. `[R2]`
+- As a researcher, I want crash recovery to behave identically regardless of provider so that orchestrator restarts don't double-bill. `[R2]`
+- As a researcher, I want the `allowed_images` ownership guard on every provider so that cleanup can't destroy an unrelated run. `[R2]`
+- As a researcher, I want to dry-run a batch locally before launching 100 cloud instances so that I catch worker bugs for free. `[R1]`
+
+## Persona 2 — Framework extender (contributor)
+
+Wants to add a new provider, swap the storage backend, or integrate a new inference API. Cares about ABC clarity, test ergonomics, and being able to iterate without cloud credentials.
+
+- As a contributor, I want a reference non-trivial `CloudRunner` besides Vast.ai so that I have a pattern to copy when adding a third provider. `[R2]`
+- As a contributor, I want to develop my new provider against `LocalRunner`'s test harness so that I can assert lifecycle invariants without signing up for an account. `[R1]`
+- As a contributor, I want a documented mapping of each ABC method to its `LocalRunner` override so that I know which methods matter and which can no-op. `[R1]`
+- As a contributor, I want to add a new inference provider by adding one enum member and a base URL so that parity with Groq/Cerebras is trivial. `[R3]`
+- As a contributor, I want ABC-level tests that all providers must pass so that I catch contract drift when I subclass. `[R2]`
+- As a contributor, I want the serverless-GPU lane (Modal, Beam, Replicate) to be documented as a *separate* ABC so that I don't try to force-fit it into `CloudRunner`. `[future]`
+- As a contributor, I want clear credentials-loading conventions so that my new provider fits alongside Vast.ai, RunPod, and R2 without bespoke config. `[R2]`
+
+## Persona 3 — CI/local developer
+
+Iterates on worker logic, fixes bugs, writes tests. Does not want GPU cost, does not want network calls, does not want to wait for an instance to boot.
+
+- As a CI user, I want to run the full `run_full_cycle` path against `LocalRunner` so that PRs can validate workers without cloud access. `[R1]`
+- As a developer, I want `LocalRunner` to skip the GPU health check gracefully on machines without CUDA so that CI runners pass. `[R1]`
+- As a developer, I want `destroy_instance` on `LocalRunner` to be a no-op so that I don't leak state when a test fails. `[R1]`
+- As a developer, I want `deploy_files` on `LocalRunner` to copy into a tempdir so that parallel test runs don't collide. `[R1]`
+- As a developer, I want `launch_worker` to return immediately with a PID I can poll so that my test loop mirrors the cloud path exactly. `[R1]`
+- As a developer, I want inference helper tests to run fully offline against mocked HTTP so that CI works without a Groq key. `[R3]`
+- As a developer, I want to inspect the workspace directory after a local run so that I can debug worker output without SSH. `[R1]`
+- As a developer, I want a Docker-based `LocalRunner` variant so that I can validate the container contract end-to-end. `[future]`
+
+## Future (unmapped)
+
+Stories that don't map to a committed roadmap item. Listed for visibility; not planned.
+
+- As a cost-conscious user, I want cross-provider cost estimation so that I can bin-pack workloads by current spot price. `[future]`
+- As an operator, I want a TUI showing active instances across all providers so that I can triage zombies centrally. `[future]`
+- As a user with sensitive data, I want an e2b or Daytona sandbox provider so that I can run untrusted worker scripts with stronger isolation than a local subprocess. `[future]`
+- As a model-ops user, I want a `ServerlessRunner` ABC so that Modal / Beam / Replicate can share an orchestrator path distinct from `CloudRunner`. `[future]`

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,66 @@
+# Vision
+
+## Purpose
+
+`vastai-gpu-runner` is a **GPU batch orchestration framework**. It provisions short-lived GPU instances, deploys a worker, collects results into object storage, and destroys the instance — with crash recovery and cost transparency along the way.
+
+It is **not**:
+
+- a long-running service scheduler
+- a training framework (PyTorch Lightning, Ray, Accelerate)
+- a Kubernetes-native orchestrator
+- an inference gateway or model router
+
+The framework owns the **lifecycle of ephemeral GPUs**. Everything the worker does once it has a GPU is the consumer's concern.
+
+## Principles
+
+| Principle | What it means |
+|---|---|
+| Provider-agnostic | `CloudRunner` ABC is the contract. Vast.ai is one implementation among several. |
+| Crash-recoverable | Atomic JSON state. Any process can die at any point and resume. |
+| Cost-transparent | Every run has a known price ceiling before it starts. Live pricing, scaling tables. |
+| Local-first dev loop | Full lifecycle runnable without a cloud account or a GPU. CI and debug cost $0. |
+| No lock-in | Consumer owns state, owns workers, owns storage format. Framework exposes primitives. |
+
+## Non-goals
+
+- **Multi-tenant SaaS.** Single-operator tool; auth is the operator's SSH/API keys.
+- **Long-running services.** Workers self-destruct after one job. No reconnect.
+- **Kubernetes.** Pods, operators, CRDs are out of scope; `CloudInstance` is deliberately flat.
+- **Replacing hosted inference.** When a job is "call a model", the framework exposes an inference helper — it does not provision a GPU for it.
+
+## Three-horizon picture
+
+### Today
+
+- One provider: Vast.ai via `VastaiRunner`.
+- One storage backend: R2 via `R2Sink`.
+- Workers run SSH + Docker.
+- Local dev requires a Vast.ai account.
+
+### Near-term (committed — see `roadmap.md`)
+
+1. **`LocalRunner`** — subprocess backend for CI and offline dev. Zero cost.
+2. **`RunPodRunner`** — second cloud backend. Validates the ABC is actually provider-agnostic.
+3. **`vastai_gpu_runner.inference` helper** — OpenAI-compatible client (Groq / Cerebras / OpenRouter) callable *from inside* workers. Not a runner.
+
+### Exploratory (deferred)
+
+- Additional SSH-lifecycle providers: TensorDock, Lambda Labs, CoreWeave.
+- Sandbox backends (e2b, Daytona) for CPU-only preflight.
+- Docker-based `LocalRunner` variant for container-contract parity.
+- A **second ABC** for serverless-GPU providers (Modal, Beam, Replicate) whose lifecycle does not map onto `CloudRunner`.
+- Hosted endpoints: HuggingFace Inference Endpoints, NVIDIA NIM.
+
+Deferred items are documented, not scheduled. They ship when a concrete user need surfaces.
+
+## Success criteria
+
+The framework is succeeding when:
+
+- A new contributor can add a provider by subclassing `CloudRunner` and writing <500 lines.
+- A user can run a worker locally with zero cloud credentials.
+- A user can switch from Vast.ai to RunPod by changing one import.
+- Cost estimates before a run match actual billing within 10%.
+- A crashed orchestrator resumes without losing work or double-billing.


### PR DESCRIPTION
## Summary

- Adds four forward-looking docs based on a provider-landscape research pass
- `docs/vision.md` — purpose, principles, non-goals, three-horizon plan
- `docs/roadmap.md` — three committed near-term items (LocalRunner, RunPodRunner, inference helper) + deferred table
- `docs/userstories.md` — stories for three personas (researcher, extender, CI dev), each tagged to a roadmap item
- `docs/architecture-v2.md` — target architecture with three-lane provider taxonomy and full ABC-method mappings for the new runners

Existing `docs/architecture.md` is untouched and remains the current-state reference.

## Test plan

- [ ] Docs render correctly on GitHub (tables, ASCII diagrams, code fences)
- [ ] Committed roadmap item names (LocalRunner, RunPodRunner, inference helper) match across all four docs
- [ ] Every user story is tagged to R1/R2/R3 or lives under "future"
- [ ] `docs/architecture-v2.md` opens with explicit "v2 = target, v1 = current" framing

Generated with Claude <noreply@anthropic.com>