### PR TITLE
docs: add social preview hero to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # vastai-gpu-runner
 
+![vastai-gpu-runner — Cloud GPU batches for Vast.ai.](.github/social-preview.png)
+
 Cloud GPU orchestration framework for [Vast.ai](https://vast.ai) — batch deployment, R2 storage, worker lifecycle, crash recovery.
 
 ## Features


### PR DESCRIPTION
Places `.github/social-preview.png` under the H1 title (mirrors hack-a-thon pattern). Image may 404 until the preview-image PR merges — harmless, resolves on merge.