### PR TITLE
fix(runner): atomic machine_id claim prevents parallel-deploy collisions

### DIFF
--- a/src/vastai_gpu_runner/runner.py
+++ b/src/vastai_gpu_runner/runner.py
@@ -174,12 +174,24 @@ class CloudRunner:
                 break
             offer = offers[attempt]
             machine_id = str(offer.get("machine_id", ""))
-            if used_machine_ids and machine_id in used_machine_ids:
+            # Atomically claim the machine_id BEFORE deploying. The previous
+            # claim-on-success pattern raced when many parallel threads
+            # started together: each read ``used_machine_ids`` (still empty)
+            # at offer-selection time and all picked offers[0], landing
+            # multiple instances on the same physical host. Two co-located
+            # workers fight for the GPU → boot-timeout / GPU-verify failures.
+            # The fix is a tentative claim under the lock now, with a
+            # release on deploy failure so the host comes back into the
+            # pool for retry.
+            if not self._try_claim_machine(machine_id, used_machine_ids, machine_lock):
                 continue
             result, error = self._try_one_offer(offer, files, attempt)
             if result is not None:
-                self._claim_machine(machine_id, used_machine_ids, machine_lock)
                 return result
+            # Deploy failed — release the tentative claim so future attempts
+            # (this thread's next iteration or another thread's next pick)
+            # can re-use the machine.
+            self._release_machine(machine_id, used_machine_ids, machine_lock)
             last_error = error
 
         return DeploymentResult(success=False, error=last_error)
@@ -244,12 +256,62 @@ class CloudRunner:
         return ""
 
     @staticmethod
+    def _try_claim_machine(
+        machine_id: str,
+        used_machine_ids: set[str] | None,
+        machine_lock: threading.Lock | object | None,
+    ) -> bool:
+        """Atomically claim a machine_id under the shared lock.
+
+        Returns ``True`` if the claim succeeded (machine was free and is
+        now reserved by this caller), ``False`` if the machine was already
+        taken by a parallel thread. ``None`` set / lock means there is
+        no shared coordination, so the claim trivially succeeds.
+
+        Pair with :func:`_release_machine` on deploy failure so the host
+        rejoins the pool for retry.
+        """
+        if used_machine_ids is None or not machine_id:
+            return True
+        if machine_lock is not None and hasattr(machine_lock, "__enter__"):
+            with machine_lock:  # type: ignore[union-attr]
+                if machine_id in used_machine_ids:
+                    return False
+                used_machine_ids.add(machine_id)
+                return True
+        if machine_id in used_machine_ids:
+            return False
+        used_machine_ids.add(machine_id)
+        return True
+
+    @staticmethod
+    def _release_machine(
+        machine_id: str,
+        used_machine_ids: set[str] | None,
+        machine_lock: threading.Lock | object | None,
+    ) -> None:
+        """Release a tentative machine_id claim after a failed deploy."""
+        if used_machine_ids is None or not machine_id:
+            return
+        if machine_lock is not None and hasattr(machine_lock, "__enter__"):
+            with machine_lock:  # type: ignore[union-attr]
+                used_machine_ids.discard(machine_id)
+        else:
+            used_machine_ids.discard(machine_id)
+
+    @staticmethod
     def _claim_machine(
         machine_id: str,
         used_machine_ids: set[str] | None,
         machine_lock: threading.Lock | object | None,
     ) -> None:
-        """Record a successfully deployed machine_id under the shared lock."""
+        """Backwards-compatible alias for the post-deploy claim path.
+
+        Kept for callers that still want the claim-on-success pattern;
+        the in-tree :meth:`run_full_cycle` now uses the atomic
+        :meth:`_try_claim_machine` + :meth:`_release_machine` pair to
+        prevent same-machine collisions across parallel deploys.
+        """
         if used_machine_ids is None:
             return
         if machine_lock is not None and hasattr(machine_lock, "__enter__"):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -99,6 +99,106 @@ class TestCloudRunner:
         assert result.success is True
         assert "m2" in used
 
+    def test_atomic_claim_prevents_parallel_collision(self) -> None:
+        """Regression: parallel ``run_full_cycle`` calls must not land on
+        the same physical machine.
+
+        Pre-fix the claim happened only after a successful deploy, so
+        every thread that started before any other completed could pick
+        ``offers[0]`` simultaneously. Two co-located workers then fight
+        for the GPU and both fail boot/verify — exactly what we observed
+        on phase5e-lac_10_11-scramble-controls-N8N7-20260427.
+
+        The fix claims the machine_id atomically before deploying and
+        releases on failure. Under that contract, two concurrent
+        ``run_full_cycle`` calls with overlapping offer lists must end up
+        on distinct machines (one wins, the other moves on to the next
+        offer).
+        """
+        import threading
+
+        used: set[str] = set()
+        lock = threading.Lock()
+
+        # Two offers, both initially free. Two threads start in parallel
+        # — without the atomic claim, both pick offers[0] and the dedup
+        # filter is too coarse to catch it.
+        offers = [
+            {"id": "1", "machine_id": "m1"},
+            {"id": "2", "machine_id": "m2"},
+        ]
+
+        results: list[CloudInstance | None] = []
+
+        def deploy_thread() -> None:
+            runner = CloudRunner()
+            # Each thread gets its own runner but shares used + lock.
+            # All gates pass — the only thing that should differ between
+            # threads is which machine they end up claiming.
+            runner.create_instance = MagicMock(
+                side_effect=lambda offer: CloudInstance(instance_id=str(offer["id"]))
+            )
+            runner.wait_for_boot = MagicMock(return_value=True)
+            runner.verify_gpu = MagicMock(return_value=True)
+            runner.deploy_files = MagicMock(return_value=True)
+            runner.setup_environment = MagicMock(return_value=True)
+            runner.launch_worker = MagicMock(return_value=True)
+            r = runner.run_full_cycle(
+                {},
+                Path("/tmp/test"),
+                offers=list(offers),  # shallow copy per thread
+                used_machine_ids=used,
+                machine_lock=lock,
+            )
+            results.append(r.instance if r.success else None)
+
+        threads = [threading.Thread(target=deploy_thread) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Both deploys should succeed — and on DIFFERENT machines. The
+        # failure mode this test pins is when both threads return the
+        # same instance_id (i.e. both picked offers[0] = m1).
+        successful = [r for r in results if r is not None]
+        assert len(successful) == 2
+        ids = {r.instance_id for r in successful}
+        assert ids == {"1", "2"}, (
+            f"Expected distinct machine assignments, got {ids} — "
+            "atomic-claim race condition has regressed."
+        )
+        assert used == {"m1", "m2"}
+
+    def test_release_on_failure_returns_machine_to_pool(self) -> None:
+        """A deploy failure must release the tentative claim so the next
+        attempt can use the same machine. Without release, a host that
+        failed to boot once would be permanently shadowed for the
+        remainder of the batch — wasting capacity.
+        """
+        import threading
+
+        used: set[str] = set()
+        lock = threading.Lock()
+
+        runner = CloudRunner()
+        runner.create_instance = MagicMock(return_value=CloudInstance(instance_id="x"))
+        runner.wait_for_boot = MagicMock(return_value=False)  # boot fails
+        runner.destroy_instance = MagicMock(return_value=True)
+
+        offers = [{"id": "1", "machine_id": "m1"}]
+        result = runner.run_full_cycle(
+            {},
+            Path("/tmp/test"),
+            offers=offers,
+            max_retries=1,
+            used_machine_ids=used,
+            machine_lock=lock,
+        )
+        assert result.success is False
+        # Critical: the failed claim must NOT linger.
+        assert "m1" not in used
+
 
 class TestCaptureDeployFailureDiagnostics:
     """New hook ``capture_deploy_failure_diagnostics`` — fires before


### PR DESCRIPTION
## Summary
- Pre-fix the dedup claim happened only AFTER a deploy succeeded, so parallel ``run_full_cycle`` calls all read ``used_machine_ids`` (still empty) at offer-selection time, picked ``offers[0]`` simultaneously, and landed on the same physical machine. Co-located workers fought for the GPU and both failed boot/verify.
- Fix: claim the machine_id atomically under ``machine_lock`` BEFORE the deploy starts; release on failure so the host rejoins the pool.
- Pinned by 2 new regression tests (parallel-collision + release-on-failure).

## Concrete failure
OralBiome-AMP `phase5e-lac_10_11-scramble-controls-N8N7-20260427` (Apr 27, 2026): 8 of 11 parallel deploys failed; Vast labels showed 3 instances on machine 47598, 3 on 13365, 2 on 53600, 2 on 53123, 2 on 51520. All collided.

## Test plan
- [x] `pytest tests/` — 207 passed (was 205)
- [x] New `test_atomic_claim_prevents_parallel_collision` — spins up 2 concurrent `run_full_cycle` calls with the same offer list, asserts distinct machine_ids
- [x] New `test_release_on_failure_returns_machine_to_pool` — asserts failed deploy doesn't permanently shadow the host

🤖 Generated with [Claude Code](https://claude.com/claude-code)