### PR TITLE
docs: architecture v4 — ProviderCleanupPolicy (resolves #19)

### DIFF
--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -25,37 +25,43 @@ business constructing) to a single, immutable `ProviderCleanupPolicy`
 object that is constructed once at boot time from the same canonical
 provider config used to build the runner factory. The runner factory
 and the cleanup policy now share **one** source of truth for "what
-counts as ours" and "what to do with not-ours" — no per-destroy
-runner construction, no drift between the `destroy_instance` ownership
-guard and the zombie-sweep ownership guard. The shared ownership
-semantics live in an `OwnershipPolicy` frozen dataclass with a single
+counts as ours" and "what to do with not-ours" — no per-destroy runner
+construction, no drift between the `destroy_instance` ownership guard
+and the zombie-sweep ownership guard. The shared ownership semantics
+live in an `OwnershipPolicy` frozen dataclass with a single
 `matches(image_ref)` method (exact reference OR tag-insensitive
 repository equality, per the v3 contract), consumed by both the
-runner and the cleanup adapter. The credential semantics live in a
-v3 `CredentialResolution` (three-state: `AVAILABLE` / `ABSENT` /
-`EXPLICITLY_DISABLED`), also shared. The `ProviderCleanupPolicy` is
-frozen (`kw_only=True`), provider-agnostic (a dataclass with two
-methods: `list_instances()` and `destroy(candidate)`), and exposes
-the destroy contract as the authoritative gate — the orchestrator
-passes every label-matching, untracked candidate to `destroy()` and
-records the `CleanupResult` (refusal or verbidden). The provider-
-specific adapters live in `providers/vastai.py` (the
-`build_vastai_cleanup_policy` factory) and, when they ship, in
-`providers/runpod.py` etc.; the core `cleanup_policy.py` module has
-provider-specific imports.
+runner and the cleanup adapter via the v3 destroy adapter (which now
+accepts `OwnershipPolicy` directly instead of a raw set). The
+credential semantics live in the v3 `CredentialState` enum and
+`CredentialResolution` dataclass (three-state: `AVAILABLE` / `ABSENT` /
+`EXPLICITLY_DISABLED`), passed verbatim into the v3 adapter (no
+internal re-resolution). The `ProviderCleanupPolicy` is frozen
+(`kw_only=True`), provider-agnostic (a dataclass with two methods:
+`list_instances()` and `destroy(candidate)`), and exposes the destroy
+contract as the authoritative gate — the orchestrator passes every
+label-matching, untracked candidate to `destroy()` and records the
+`CleanupResult` (typed `CleanupVerdict` or `CleanupRefusal`). The
+provider-specific adapters live in `providers/vastai.py` (the
+`build_vastai_cleanup_policy` factory); the core `cleanup_policy.py`
+module has **no** provider-specific imports. The Vast.ai factory
+wraps `list_vastai_instances` so the v3 contract's
+`EXPLICITLY_DISABLED` short-circuit is honored *before* enumeration.
 
 Diff vs v3 once v3 is implemented:
 
-- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen), `CleanupRefusal` enum (`UNOWNED | NO_CREDENTIALS | CREDENTIALS_DISABLED`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`)
-- **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc.)
-- **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(config)` — provider-owned factory (core module does not import provider adapters)
+- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, with provider-neutral display fields), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc., with `docker_image` non-empty + ownership invariant)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(config)` — provider-owned factory (core module has no provider imports)
 - **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`
+- **~** `providers/destroy_adapters/vastai.py:destroy_vastai_instance` accepts `ownership: OwnershipPolicy` directly (replaces `allowed_images: frozenset[str]`); accepts `credentials: CredentialResolution | None` (defaults to `read_vastai_api_key()` for back-compat direct callers). The v3 implementation must adopt this signature.
 - **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (already required; v3 design). The orchestrator calls `policy.list_instances()` and `policy.destroy(candidate)` — it never branches on `Provider`, never imports provider modules.
-- **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and the tracked-id exclusion stay on the orchestrator (per-batch scope). Every other decision (eligibility, ownership, credentials, hostile classification) is delegated to `policy.destroy()`.
-- **~** `VastaiRunner.__init__` keeps the `allowed_images` parameter for the direct-construction back-compat path. `VastaiRunner.from_config(config)` is the canonical entry point used by the CLI.
+- **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and the tracked-id exclusion stay on the orchestrator (per-batch scope). Every other decision (eligibility, ownership, credentials) is delegated to `policy.destroy()`. The orchestrator logs every non-`DESTROYED` outcome (CLI fallbacks, LEAKED, UNKNOWN, refusals).
+- **~** `VastaiRunner.__init__` keeps the `allowed_images` parameter for the direct-construction back-compat path (builds an `OwnershipPolicy` from it). `VastaiRunner.from_config(config)` is the canonical entry point used by the CLI and passes the `OwnershipPolicy` instance directly (no conversion to a set).
+- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new `VastaiProviderConfig` + `ProviderCleanupPolicy` API. The CLI no longer parses Vast.ai JSON directly. The `--allowed-images` flag is preserved as canonical; `--owned-images` is added as a documented alias.
 - **—** `orchestrator.py:sweep_zombie_instances` (v3 deletion) — reaffirmed. The v4 implementation removes the last direct caller.
 - **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) — reaffirmed. Credential loading lives in `providers/destroy_adapters/vastai.py` (v3).
-- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new `VastaiProviderConfig` + `ProviderCleanupPolicy` API. The CLI no longer parses Vast.ai JSON directly.
+- **—** `providers/vastai.py:_image_is_allowed` (raw set check) — replaced by `OwnershipPolicy.matches()`. The semantic drift between runner and adapter is impossible because both call the same method.
 - **~** `tests/test_orchestrator.py` and `tests/test_batch.py` — mock `cleanup_policy.list_instances()` and `cleanup_policy.destroy()` instead of `sweep_zombie_instances`. New `tests/test_cleanup_policy.py` for the policy unit tests.
 
 ## Why Option B (canonical config) over Option A (per-runner `destroy_zombie`)
@@ -77,39 +83,58 @@ compete for the same role. The canonical config is the single
 source of truth for both the deployment identity and the destruction
 identity.
 
-## What changes vs the v4 first draft (5th-pass review)
+## What changes vs the v4 first + second drafts (5th + 6th pass reviews)
 
-The first draft of this doc was reviewed by ChatGPT and rejected
-with five BLOCKERs and seven CONCERNs. The full diff to the first
-draft is in `docs/architecture-v4-cleanup-policy.review-1.md`. The
-substantive changes:
+The first draft was rejected with 5 BLOCKERs and 7 CONCERNs. The
+second draft was rejected with 7 BLOCKERs, 2 CONCERNs, and 3 NITs.
+This third draft addresses every finding. The substantive changes:
 
-- **Dataclass field ordering.** Switched to `@dataclass(frozen=True, kw_only=True)` so callback fields can be required without ordering pitfalls. The first draft had `destroy_fn` required after fields with defaults — a `TypeError` on import.
-- **List-instances on the policy.** First draft called `policy.list_provider_instances()` but never defined the method. The v4.2 design adds `list_instances_fn: Callable[[], list[InstanceCandidate]]` to the policy and a public `list_instances()` method that the orchestrator calls.
-- **`is_candidate` / `destroy` split.** The first draft made `is_candidate` perform the ownership check, which the orchestrator skipped on `False` — so `destroy()` could never produce `UNOWNED` from the normal flow. The v4.2 design removes the ownership check from `is_candidate` (it is now a cheap eligibility prefilter that returns `False` for ineligible states only) and makes `destroy()` authoritative: it re-validates ownership, credentials, and eligibility every call. The orchestrator passes every label-matching, untracked candidate to `destroy()` and records the `CleanupResult`.
-- **Hostile check.** First draft placed a `hostile_check` boolean and `hostile_threshold_seconds` int on the policy, with a destructive branch above the ownership check. The check was semantically redundant — unowned candidates are refused regardless of age. v4.2 removes the hostile check from the policy (deferred to a separate audit stage that YAGNI for now).
-- **Credential model.** First draft used `api_key: str = ""` and three enum values were flattened. v4.2 uses v3's `CredentialResolution` (three-state: `AVAILABLE` / `ABSENT` / `EXPLICITLY_DISABLED`) frozen in the canonical config. `EXPLICITLY_DISABLED` short-circuits the policy before enumeration (no API/CLI calls). `ABSENT` uses the CLI fallback with CLI ownership verification (the v3 contract).
-- **Ownership semantics.** First draft used `repository_image: Optional[str]` and exact string equality. v4.2 introduces `OwnershipPolicy` with `owned_images: AbstractSet[str] | None` and `matches(image_ref)` (exact reference OR tag-insensitive repository equality, per v3). Both the runner and the cleanup adapter call `matches()`. The deployment image is required to be in `owned_images` at construction time (fail-closed).
-- **CLI wiring.** First draft used `VastaiProviderConfig.from_env().__class__(allowed_images=image)` — a fresh default config that discarded the loaded credential. v4.2 uses `dataclasses.replace(base, ...)`.
-- **Provider factories.** First draft put `from_vastai_config` / `from_runpod_config` in the core module. v4.2 moves the Vast.ai factory to `providers/vastai.py:build_vastai_cleanup_policy`. The RunPod factory is omitted entirely (lands with the RunPod adapter).
-- **State filter.** First draft's `candidate_filter` accepted only `("running", "stopped", "exited")` — too narrow. v4.2 makes `list_*_instances()` return a complete enumeration; the policy's `destroy()` applies the eligibility filter authoritatively.
-- **`CleanupResult` invariants.** First draft's `destroyed: int = 0` allowed empty results, negative values, and combinations. v4.2 adds `__post_init__` invariants: exactly one of `destroyed: bool` or `refusal: CleanupRefusal` is set; `error` is non-empty on failure; comparisons to v3 use the `DestroyVerdict` enum, not the string `"destroyed"`.
-- **Migration order.** First draft had 7 steps in a logical order but skipped the existing CLI commands and the caller audit. v4.2 reorders the steps (canonical types first, adapter before orchestrator, audit before deletion) and explicitly addresses the `cleanup` and `instances` CLI commands.
+### Applied from the 5th-pass review
+
+- Dataclass field ordering switched to `@dataclass(frozen=True, kw_only=True)` (BLOCKER 1).
+- `list_instances_fn` + `list_instances()` method on the policy (BLOCKER 2).
+- `destroy()` is authoritative; `is_candidate` was removed from the orchestrator's call path (BLOCKER 3).
+- Hostile check removed (BLOCKER 4).
+- v3 `CredentialResolution` + `CredentialResolutionResult` used (now corrected — see 6th-pass BLOCKER 3 below).
+- `OwnershipPolicy.matches()` introduced (now corrected — see 6th-pass BLOCKER 1 below).
+- CLI uses `dataclasses.replace` (BLOCKER 7).
+- Provider factories moved to `providers/vastai.py` (CONCERN 8).
+- State filter removed; complete enumeration + authoritative eligibility (now corrected — see 6th-pass CONCERN 9 below).
+- `CleanupResult` invariants added (now tightened — see 6th-pass CONCERN 8 below).
+- `from_runpod_config` removed (CONCERN 11).
+- Migration order revised (CONCERN 12).
+
+### Applied from the 6th-pass review (this pass)
+
+- **`_repository(image_ref)` fixed** to match v3 contract: strips digest, strips only the final tag separator (after the last `/`), preserves registry and port, normalises both candidate and owned entries. The previous implementation returned the digest reference unchanged and didn't normalise the owned set. (BLOCKER 1)
+- **Runner and adapter consume `OwnershipPolicy.matches()` directly.** The runner's `__init__` keeps the `allowed_images` parameter as a deprecated back-compat alias (it builds an `OwnershipPolicy` from it); `from_config` passes the `OwnershipPolicy` instance unchanged. The v3 `destroy_vastai_instance` adapter is updated to accept `ownership: OwnershipPolicy` (replacing `allowed_images: frozenset[str]`); both the runner and the cleanup factory call `ownership.matches(image_uuid)`. (BLOCKER 2)
+- **v3 type names used exactly.** The v3 design has `CredentialState` (enum) + `CredentialResolution` (dataclass with `state` and `key` fields, `ValueError` invariants). The v4 second draft misnamed these. (BLOCKER 3)
+- **`EXPLICITLY_DISABLED` short-circuits before enumeration.** The Vast.ai factory wraps `list_vastai_instances` so that an explicit-empty credential skips the CLI enumeration step entirely (the v3 contract). The factory wires the wrapped function into `list_instances_fn`, not the raw helper. The integration test asserts that `vastai_cmd` is not called when credentials are disabled. (BLOCKER 4)
+- **CLI fallback and DestroyResult translation corrected.** The `_destroy` callback now (a) refuses `EXPLICITLY_DISABLED` without provider calls, (b) uses the canonical API key for the REST path, (c) runs the v3 CLI fallback for `ABSENT`, (d) returns `CLI_ATTEMPTED` (not `DESTROYED`) after a successful CLI command, (e) translates all four v3 verdicts (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`) and all three v3 refusals (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED`). `CleanupResult` uses `verdict: CleanupVerdict | None` and `refusal: CleanupRefusal | None` (mutually exclusive), not a boolean. The orchestrator logs every non-`DESTROYED` outcome. (BLOCKER 5)
+- **`docker_image` non-empty enforced.** `VastaiProviderConfig.__post_init__` rejects empty or whitespace-only `docker_image`. `from_env()` uses `DEFAULT_IMAGE if docker_image is None else docker_image` — explicit empty string is a `ValueError`. (BLOCKER 6)
+- **Undefined names removed.** `cleanup_policy.py` adds `import logging; logger = logging.getLogger(__name__)`. `cli.py` adds `from vastai_gpu_runner.cleanup_policy import OwnershipPolicy`. Unused `_TAG_RE`, `Iterable`, `DestroyResult` (TYPE_CHECKING), and `VASTAI_POLICY` imports are removed. (BLOCKER 7)
+- **`CleanupResult` invariants tightened.** Now uses `verdict | refusal` (mutually exclusive) instead of `destroyed: bool`. `DESTROYED` requires empty `error`; every other outcome requires non-empty `error`. (CONCERN 8)
+- **Authoritative eligibility implemented.** The factory's `_destroy` checks the candidate's state against an explicit `ELIGIBLE_STATES` set (defined as a module constant in `providers/vastai.py`) and returns `INELIGIBLE_STATE` on failure. The orchestrator passes every candidate to `destroy()`; the factory decides. (CONCERN 9)
+- **`InstanceCandidate` enriched for CLI display.** Adds `gpu_model: str = ""`, `cost_per_hour: float = 0.0`, `ownership_key: str = ""` (provider-neutral) alongside the existing `image_uuid: str = ""` (Vast.ai-specific). The Vast.ai factory fills both `image_uuid` and `ownership_key` (same value). Future RunPod factory will fill `ownership_key` only. (CONCERN 10)
+- **CLI flag renamed carefully.** `--allowed-images` is preserved as canonical; `--owned-images` is added as a documented alias. The rename is deferred to a separate CLI compatibility change. (CONCERN 11)
+- **`provider=Provider.VASTAI` simplified** (NIT 12) and provider-mismatch diagnostic improved (NIT 13).
+- **Stale prose cleaned up.** All references to `is_candidate`, "hostile classification", "verbidden", and "the core module has provider-specific imports" are corrected. (NIT 14)
 
 ## Module taxonomy
 
 The v4 doc adds one new module at the layer above the v3 destroy
 protocol. The `CloudRunner` ABC, `BatchOrchestrator`, `unit_lifecycle`,
 `providers/destroy`, and `providers/destroy_adapters/vastai` are
-unchanged in shape (v3 implementation is still a prerequisite).
+unchanged in shape (v3 implementation is still a prerequisite, with
+the v3 adapter signature amended per BLOCKER 2 above).
 
 ### New: `cleanup_policy` — owns the DTOs + the generic policy class
 
-Owns: `InstanceCandidate` (frozen DTO), `CleanupRefusal` enum,
-`CleanupResult` (typed return), `OwnershipPolicy` (frozen, shared
-ownership semantics), `ProviderCleanupPolicy` (frozen, `kw_only`,
-provider-agnostic, holds the `list_instances_fn` and `destroy_fn`
-callbacks).
+Owns: `InstanceCandidate` (frozen DTO), `CleanupVerdict` enum,
+`CleanupRefusal` enum, `CleanupResult` (typed return), `OwnershipPolicy`
+(frozen, shared ownership semantics), `ProviderCleanupPolicy`
+(frozen, `kw_only`, provider-agnostic, holds the `list_instances_fn`
+and `destroy_fn` callbacks).
 
 Does **not** own: provider-specific adapters (live in `providers/*`),
 REST URLs, API key paths, the destroy protocol loop (lives in
@@ -120,9 +145,9 @@ core module imports nothing from `providers/`.
 
 The Vast.ai factory is a provider-owned function. It reads the
 canonical `VastaiProviderConfig`, wires the v3 `destroy_vastai_instance`
-+ `list_vastai_instances` into the policy, and returns the configured
-`ProviderCleanupPolicy`. The factory is the single point of contact
-between the Vast.ai adapter and the generic policy.
++ a wrapped `list_vastai_instances` into the policy, and returns the
+configured `ProviderCleanupPolicy`. The factory is the single point
+of contact between the Vast.ai adapter and the generic policy.
 
 The RunPod factory is omitted from this doc — it lands with the
 RunPod adapter (roadmap item 2). The shape is defined by the
@@ -159,6 +184,9 @@ provider-agnostic from day one.
 │  providers/destroy (providers/destroy.py)       │  v3: belt-and-suspenders protocol
 ├─────────────────────────────────────────────────┤
 │  providers/destroy_adapters/vastai.py           │  v3: Vast.ai REST callbacks + policy
+│    └── destroy_vastai_instance(ownership=       │
+│        OwnershipPolicy, credentials=            │
+│        CredentialResolution | None)             │
 ├─────────────────────────────────────────────────┤
 │  CloudRunner (runner.py) ── Lane A ABC          │  Provider-agnostic lifecycle
 ├──────────────┬──────────────┬───────────────────┤
@@ -170,50 +198,54 @@ provider-agnostic from day one.
 
 Single frozen dataclass, owned by `cleanup_policy.py`. The v3
 ownership semantics (exact reference OR tag-insensitive repository
-equality) live here, in one method, consumed by both the runner
-and the cleanup adapter.
+equality, preserving registry and port) live here, in one method,
+consumed by both the runner and the cleanup adapter.
 
 ```python
 # src/vastai_gpu_runner/cleanup_policy.py
 from __future__ import annotations
 
-import re
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import AbstractSet
+from enum import Enum
+from typing import AbstractSet, Callable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vastai_gpu_runner.types import Provider
+
+logger = logging.getLogger(__name__)
 
 
-# Tag-insensitive repository match: strip the tag and (optional) registry,
-# then require equality. Prevents the v3 failure modes
-# ("myorg/app:1.0" matches "myorg/app-malicious:latest"; "registry:5000/myorg/app"
-# matches "registry-malicious/myorg/app").
-_TAG_RE = re.compile(r"[:@]")
-
-
-def _repository(image_ref: str) -> str:
+def _repository(ref: str) -> str:
     """Return the tag-insensitive repository name from an image reference.
 
-    Strips the tag (`repo:tag` → `repo`) and the registry prefix
-    (`registry:5000/repo` → `repo`). The result is the canonical
-    "this image, regardless of tag or registry" name.
+    Strips the digest (`repo@sha256:...` → `repo`), strips only the
+    final tag separator (after the last `/`), and preserves the
+    registry and port. This prevents the v3 failure modes
+    ("myorg/app:1.0" matching "myorg/app-malicious:latest";
+    "registry:5000/myorg/app" matching "registry-malicious/myorg/app").
+
+    Returns the empty string for malformed references (multiple
+    `@`, multiple `:` in the final segment, whitespace-only,
+    multiple-tag references).
     """
-    ref = image_ref.strip()
+    ref = ref.strip()
     if not ref:
         return ""
-    # sha256 digests: strip the @sha256:...; treat the digest as authoritative —
-    # if the digest matches, the image matches; the tag is irrelevant.
-    if "@sha256:" in ref:
-        return ref
-    # No tag ('' OR ''): nothing to strip.
-    if ":" not in ref.split("/")[-1]:
-        return ref
-    # Strip the first : after the last / (the tag separator).
-    last_slash = ref.rfind("/")
-    if last_slash == -1:
-        return ref
-    head = ref[:last_slash]
-    tail = ref[last_slash + 1 :]
-    return f"{head}/{tail.split(':', 1)[0]}"
+    if ref.count("@") > 1:
+        return ""
+    without_digest = ref.split("@", 1)[0]
+    if not without_digest:
+        return ""
+    final_segment = without_digest.rsplit("/", 1)[-1]
+    if final_segment.count(":") > 1:
+        return ""
+    last_slash = without_digest.rfind("/")
+    last_colon = without_digest.rfind(":")
+    if last_colon > last_slash:
+        return without_digest[:last_colon]
+    return without_digest
 
 
 @dataclass(frozen=True)
@@ -238,70 +270,97 @@ class OwnershipPolicy:
           mutation is impossible).
         - ``None`` and ``frozenset()`` are distinct: ``None`` opts
           out, ``frozenset()`` opts in but rejects everything.
+        - The normalised owned repositories are precomputed and
+          cached so ``matches()`` is O(1) per call.
     """
 
     owned_images: AbstractSet[str] | None = None
 
     def __post_init__(self) -> None:
-        if self.owned_images is not None:
-            # Coerce to frozenset; freeze the field.
-            object.__setattr__(self, "owned_images", frozenset(self.owned_images))
+        if self.owned_images is None:
+            object.__setattr__(self, "_normalised", None)
+            return
+        frozen = frozenset(self.owned_images)
+        object.__setattr__(self, "owned_images", frozen)
+        object.__setattr__(
+            self,
+            "_normalised",
+            frozenset(repo for o in frozen if (repo := _repository(o))),
+        )
 
     def matches(self, image_ref: str) -> bool:
         """Return True if ``image_ref`` is owned by this policy.
 
         Returns True unconditionally when ``owned_images is None``
         (ownership check disabled). Otherwise returns True iff
-        the image reference OR its tag-insensitive repository
-        matches an entry in ``owned_images``.
+        the tag-insensitive repository of ``image_ref`` matches
+        the tag-insensitive repository of any entry in
+        ``owned_images``.
+
+        Examples (assuming ``owned_images={"myorg/app:1.0"}``):
+            >>> matches("myorg/app:1.0")        # True (exact)
+            >>> matches("myorg/app:latest")     # True (repo match)
+            >>> matches("myorg/app-malicious")  # False (different repo)
+            >>> matches("registry:5000/myorg/app:1.0")  # False (different registry)
         """
         if self.owned_images is None:
             return True
         if not image_ref:
             return False
-        if image_ref in self.owned_images:
-            return True
         repo = _repository(image_ref)
-        if repo and repo in self.owned_images:
-            return True
-        return False
+        if not repo:
+            return False
+        return repo in self._normalised  # type: ignore[operator]
 ```
 
-## `CredentialResolution` shape
+## `CredentialState` + `CredentialResolution` shape (v3 shapes, used unchanged)
 
-The v3 design defines `CredentialResolution` in
-`providers/destroy_adapters/vastai.py`. The v4 design pulls it into
-the canonical config as-is, since v3 implementation is a prerequisite
-for v4.
+The v3 design defines these types in `providers/destroy_adapters/vastai.py`.
+The v4 design uses them unchanged — the names matter because the v3
+adapter (when implemented) and the v4 factory (this design) must
+agree.
 
 ```python
-# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py (v3 shape)
-class CredentialResolution(Enum):
+# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py (v3 shape — verbatim)
+class CredentialState(Enum):
+    """Three-state credential resolution."""
     AVAILABLE = "available"
     ABSENT = "absent"
     EXPLICITLY_DISABLED = "explicitly_disabled"
 
 
 @dataclass(frozen=True)
-class CredentialResolutionResult:
-    """Output of ::func::`read_vastai_api_key`. EMPTY unless state is AVAILABLE."""
-    state: CredentialResolution
-    api_key: str = ""
+class CredentialResolution:
+    """Output of read_vastai_api_key(). EMPTY unless state is AVAILABLE.
+
+    Invariants (enforced in __post_init__):
+        - AVAILABLE requires non-empty, pre-stripped key.
+        - ABSENT and EXPLICITLY_DISABLED require empty key.
+
+    Note: pre-stripped means the key has no leading/trailing
+    whitespace. The v3 read_vastai_api_key() strips before checking.
+    """
+    state: CredentialState
+    key: str = ""
 
     def __post_init__(self) -> None:
-        if self.state == CredentialResolution.AVAILABLE:
-            assert self.api_key, "AVAILABLE requires non-empty api_key"
+        if self.state == CredentialState.AVAILABLE:
+            if not self.key or self.key != self.key.strip():
+                raise ValueError(
+                    "CredentialResolution.AVAILABLE requires non-empty, pre-stripped key"
+                )
         else:
-            assert not self.api_key, f"{self.state.value} requires empty api_key"
+            if self.key:
+                raise ValueError(
+                    f"CredentialResolution.{self.state.value} requires empty key"
+                )
 ```
 
 ## `VastaiProviderConfig` shape
 
 The canonical config is a frozen dataclass that owns both the
 runner-side and the policy-side configuration. The runner factory
-and the cleanup-policy factory both read from it. This is the
-"share one canonical config" pattern the v3 5th-pass review
-recommended.
+and the cleanup-policy factory both read from it.
 
 ```python
 # src/vastai_gpu_runner/providers/vastai.py
@@ -316,33 +375,34 @@ class VastaiProviderConfig:
     drift.
 
     Invariants:
+        - ``docker_image`` is non-empty and pre-stripped.
         - ``docker_image`` is in ``ownership.owned_images`` unless
           ``ownership.owned_images is None`` (ownership check disabled).
-        - ``credentials`` is a v3 ``CredentialResolutionResult`` (frozen).
+        - ``credentials`` is a v3 ``CredentialResolution`` (frozen).
     """
 
     docker_image: str = DEFAULT_IMAGE
     ownership: OwnershipPolicy = field(default_factory=OwnershipPolicy)
-    credentials: CredentialResolutionResult = field(
-        default_factory=lambda: CredentialResolutionResult(
-            state=CredentialResolution.ABSENT,
-        )
+    credentials: CredentialResolution = field(
+        default_factory=lambda: CredentialResolution(state=CredentialState.ABSENT)
     )
     min_gpu_vram_mib: int = MIN_GPU_VRAM_MIB
     setup_commands: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        if self.ownership.owned_images is not None:
-            if (
-                self.docker_image
-                and not self.ownership.matches(self.docker_image)
-            ):
-                msg = (
-                    f"VastaiProviderConfig invariant violated: "
-                    f"docker_image={self.docker_image!r} is not in "
-                    f"ownership.owned_images={set(self.ownership.owned_images)!r}"
-                )
-                raise ValueError(msg)
+        if not self.docker_image or self.docker_image != self.docker_image.strip():
+            raise ValueError(
+                "VastaiProviderConfig.docker_image must be a non-empty, pre-stripped reference"
+            )
+        if self.ownership.owned_images is not None and not self.ownership.matches(
+            self.docker_image
+        ):
+            raise ValueError(
+                f"VastaiProviderConfig invariant violated: docker_image="
+                f"{self.docker_image!r} is not owned by "
+                f"ownership.owned_images="
+                f"{set(self.ownership.owned_images)!r}"
+            )
 
     @classmethod
     def from_env(
@@ -353,91 +413,231 @@ class VastaiProviderConfig:
     ) -> "VastaiProviderConfig":
         """Build from environment / config files.
 
-        Reads the canonical Vast.ai API key path (the v3
-        ``read_vastai_api_key``) and the env-var defaults. The
-        CLI uses ``dataclasses.replace`` to overlay the
+        Reads the v3 ``read_vastai_api_key()`` into ``credentials``.
+        The CLI uses ``dataclasses.replace`` to overlay the
         project-specific values on top of this base.
+
+        Note: explicit empty ``docker_image`` is rejected by
+        ``__post_init__``; only ``None`` triggers the default.
         """
         from vastai_gpu_runner.providers.destroy_adapters.vastai import (
             read_vastai_api_key,
         )
+        resolved_image = DEFAULT_IMAGE if docker_image is None else docker_image
         return cls(
-            docker_image=docker_image or DEFAULT_IMAGE,
+            docker_image=resolved_image,
             ownership=OwnershipPolicy(owned_images=owned_images),
             credentials=read_vastai_api_key(),
         )
+```
 
+## Vast.ai adapter signature change (v3 amendment)
 
+The v3 design's `destroy_vastai_instance` accepts
+`instance_id` and `allowed_images: frozenset[str]`. The v4 design
+extends this signature: `allowed_images` is replaced by
+`ownership: OwnershipPolicy`, and `credentials` is added as an
+optional parameter (defaults to `read_vastai_api_key()` for
+back-compat direct callers).
+
+The v3 implementation must adopt this signature when it lands. The
+canonical runner and cleanup-policy construction pass the
+`OwnershipPolicy` instance unchanged (no conversion to a set).
+
+```python
+# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py (v3 + v4 signature)
+def destroy_vastai_instance(
+    instance_id: str,
+    *,
+    ownership: OwnershipPolicy,
+    credentials: Optional[CredentialResolution] = None,
+) -> DestroyResult:
+    """Stop + delete + verify a Vast.ai instance.
+
+    Args:
+        instance_id: Vast.ai instance ID.
+        ownership: Shared ownership policy. The runner and the
+            cleanup adapter both pass the same instance.
+        credentials: Pre-resolved credential state. When None
+            (the default), falls back to ``read_vastai_api_key()``
+            — preserves the v3 back-compat path for direct callers.
+
+    Returns:
+        ``DestroyResult`` with either ``verdict`` or ``refusal``
+        (never both). The cleanup policy translates this into a
+        ``CleanupResult`` with ``CleanupVerdict`` or
+        ``CleanupRefusal``.
+    """
+    resolution = credentials or read_vastai_api_key()
+    # ... rest unchanged from v3 design, but using ownership.matches()
+    # instead of the raw _image_is_allowed set check ...
+```
+
+The v2 `verify_instance_ownership` helper is updated to accept
+`OwnershipPolicy` directly:
+
+```python
+# src/vastai_gpu_runner/providers/vastai.py (v4 amendment)
+def verify_instance_ownership(
+    instance_id: str,
+    *,
+    ownership: OwnershipPolicy,
+) -> bool:
+    """Check that a Vast.ai instance belongs to the caller before destruction.
+
+    Uses ``ownership.matches(image_uuid)`` for the ownership check.
+    """
+    if ownership.owned_images is None:
+        return True
+    try:
+        raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
+        instances = json.loads(raw)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Cannot verify ownership of instance %s (API error: %s) — refusing to destroy",
+            instance_id,
+            exc,
+        )
+        return False
+    inst = _find_instance(instances, instance_id)
+    if inst is None:
+        logger.info("Instance %s not found in account (already destroyed?)", instance_id)
+        return True
+    image = str(inst.get("image_uuid", ""))
+    if ownership.matches(image):
+        return True
+    logger.error(
+        "BLOCKED: instance %s belongs to another project (image=%s). Will NOT destroy.",
+        instance_id,
+        image,
+    )
+    return False
+```
+
+## `VastaiRunner` shape
+
+The `__init__` keeps the `allowed_images` parameter as a deprecated
+back-compat path (it builds an `OwnershipPolicy` from it). The
+`from_config` classmethod is the canonical entry point.
+
+```python
+# src/vastai_gpu_runner/providers/vastai.py (VastaiRunner updates)
 class VastaiRunner(CloudRunner):
-    # ... existing constructor preserved for direct callers ...
     def __init__(
         self,
         config: DeploymentConfig | None = None,
         *,
-        allowed_images: frozenset[str] | None = None,
+        ownership: OwnershipPolicy | None = None,
+        allowed_images: frozenset[str] | None = None,  # DEPRECATED: build OwnershipPolicy instead
         docker_image: str = DEFAULT_IMAGE,
         min_gpu_vram_mib: int = MIN_GPU_VRAM_MIB,
         setup_commands: list[str] | None = None,
     ) -> None:
+        """Initialize Vast.ai runner with deployment config and safety guards."""
+        if ownership is None and allowed_images is not None:
+            # Back-compat: build OwnershipPolicy from the deprecated set.
+            import warnings
+
+            warnings.warn(
+                "VastaiRunner(allowed_images=...) is deprecated; "
+                "build an OwnershipPolicy and pass ownership= instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            ownership = OwnershipPolicy(owned_images=frozenset(allowed_images))
         super().__init__(config)
-        self.allowed_images = allowed_images
+        self.ownership = ownership
+        # Preserve .allowed_images as a property for back-compat reads.
+        self._allowed_images_for_backcompat = (
+            frozenset(ownership.owned_images)
+            if ownership and ownership.owned_images is not None
+            else None
+        )
         self.docker_image = docker_image
         self.min_gpu_vram_mib = min_gpu_vram_mib
         self._setup_commands = setup_commands or []
+
+    @property
+    def allowed_images(self) -> frozenset[str] | None:
+        """Back-compat read access. New code should use ``self.ownership``."""
+        return self._allowed_images_for_backcompat
 
     @classmethod
     def from_config(cls, canonical: VastaiProviderConfig) -> "VastaiRunner":
         """Build a VastaiRunner from the canonical config.
 
-        Preserves the existing constructor as a back-compat path —
-        direct callers (unit tests, scripts) keep working. The CLI
-        uses this classmethod.
+        Passes the canonical ``OwnershipPolicy`` instance unchanged
+        — the runner and the cleanup policy will call the same
+        ``matches()`` method on the same instance.
         """
         return cls(
-            allowed_images=(
-                frozenset(canonical.ownership.owned_images)
-                if canonical.ownership.owned_images is not None
-                else None
-            ),
+            ownership=canonical.ownership,
             docker_image=canonical.docker_image,
             min_gpu_vram_mib=canonical.min_gpu_vram_mib,
             setup_commands=list(canonical.setup_commands),
         )
+
+    def destroy_instance(self, instance: CloudInstance) -> bool:
+        """Destroy a Vast.ai instance (with ownership safety guard)."""
+        if not verify_instance_ownership(
+            instance.instance_id,
+            ownership=self.ownership or OwnershipPolicy(),
+        ):
+            logger.error(
+                "REFUSED to destroy instance %s — ownership check failed.",
+                instance.instance_id,
+            )
+            return False
+        # ... rest unchanged from v2 ...
 ```
 
 ## `list_vastai_instances` shape
 
-The provider's read-only enumeration helper. The orchestrator's
-`_sweep_zombies` calls `policy.list_instances()` (which delegates
-to the wired `list_instances_fn`); the orchestrator never parses
-Vast.ai JSON directly.
+The provider's read-only enumeration helper. The Vast.ai factory
+wraps this with the EXPLICITLY_DISABLED short-circuit; the core
+helper is unchanged.
 
 ```python
 # src/vastai_gpu_runner/providers/vastai.py
+# Module-level constant: states that are safe for the cleanup sweep to
+# act on. Anything not in this set returns CleanupRefusal.INELIGIBLE_STATE
+# from the factory's _destroy callback.
+VASTAI_ELIGIBLE_STATES: frozenset[str] = frozenset(
+    {"running", "stopped", "exited", "loading", "created"}
+)
+
+
 def list_vastai_instances() -> list[InstanceCandidate]:
     """Read-only enumeration of Vast.ai instances on this account.
 
-    Returns ``InstanceCandidate`` records (provider-agnostic DTOs)
-    so the orchestrator's zombie sweep does not have to parse
-    Vast.ai's JSON shape. A failure to enumerate returns an empty
-    list — the orchestrator's existing exception handling logs the
-    failure and continues.
+    Returns ``InstanceCandidate`` records so the orchestrator's
+    zombie sweep does not have to parse Vast.ai's JSON shape. A
+    failure to enumerate returns an empty list — the orchestrator's
+    existing exception handling logs the failure and continues.
+
+    NB: this helper does NOT enforce the EXPLICITLY_DISABLED
+    short-circuit. The factory wraps this function with the
+    short-circuit so the policy's list_instances() honors the v3
+    contract.
     """
-    from vastai_gpu_runner.cleanup_policy import InstanceCandidate
+    candidates: list[InstanceCandidate] = []
     try:
         raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
         instances = json.loads(raw)
     except (RuntimeError, json.JSONDecodeError) as exc:
         logger.warning("list_vastai_instances: enumeration failed: %s", exc)
-        return []
-    candidates: list[InstanceCandidate] = []
+        return candidates
     for inst in instances:
         try:
+            image_uuid = str(inst.get("image_uuid", ""))
             candidates.append(
                 InstanceCandidate(
                     provider=Provider.VASTAI,
                     instance_id=str(inst.get("id", "")),
-                    image_uuid=str(inst.get("image_uuid", "")),
+                    image_uuid=image_uuid,
+                    ownership_key=image_uuid,  # Vast.ai's ownership key is its image
+                    gpu_model=str(inst.get("gpu_name", "")),
+                    cost_per_hour=float(inst.get("dph_total", 0.0) or 0.0),
                     label=str(inst.get("label", "")),
                     state=str(inst.get("actual_status", "")),
                     started_at=float(inst.get("start_date", 0.0) or 0.0),
@@ -448,22 +648,25 @@ def list_vastai_instances() -> list[InstanceCandidate]:
     return candidates
 ```
 
-## `ProviderCleanupPolicy` shape
-
-The core policy dataclass. Frozen, `kw_only=True`, provider-agnostic.
-Holds two callbacks (`list_instances_fn` and `destroy_fn`) that
-the provider-owned factory wires. The orchestrator calls only
-`list_instances()` and `destroy(candidate)`.
+## `InstanceCandidate`, `CleanupVerdict`, `CleanupRefusal`, `CleanupResult` shapes
 
 ```python
-# src/vastai_gpu_runner/cleanup_policy.py
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Callable, Optional, TYPE_CHECKING
+# src/vastai_gpu_runner/cleanup_policy.py (additions)
 
-if TYPE_CHECKING:
-    from vastai_gpu_runner.providers.destroy import DestroyResult
-    from vastai_gpu_runner.types import Provider
+
+class CleanupVerdict(Enum):
+    """Outcome verdicts returned by ``policy.destroy``.
+
+    These are protocol outcomes — the destroy protocol ran to
+    completion and reported a verdict. ``DESTROYED`` is the only
+    success; the others are observable non-success states that
+    the orchestrator logs distinctly.
+    """
+
+    DESTROYED = "destroyed"
+    CLI_ATTEMPTED = "cli_attempted"  # CLI fallback ran, destruction not confirmed
+    LEAKED = "leaked"                # Protocol ran but instance was resurrected
+    UNKNOWN = "unknown"              # Protocol did not report a clear outcome
 
 
 class CleanupRefusal(Enum):
@@ -474,9 +677,11 @@ class CleanupRefusal(Enum):
     the candidate.
     """
 
-    UNOWNED = "unowned"
-    NO_CREDENTIALS = "no_credentials"
-    CREDENTIALS_DISABLED = "credentials_disabled"
+    OWNERSHIP = "ownership"               # image/template not owned by this policy
+    NO_CREDENTIALS = "no_credentials"     # no API key configured; CLI fallback attempted
+    CREDENTIALS_DISABLED = "credentials_disabled"  # VASTAI_API_KEY="" — CLI fallback forbidden
+    INELIGIBLE_STATE = "ineligible_state" # candidate.state not in provider's eligible_states
+    PROVIDER_MISMATCH = "provider_mismatch"  # candidate.provider != policy.provider
 
 
 @dataclass(frozen=True)
@@ -485,15 +690,22 @@ class InstanceCandidate:
 
     Frozen so the policy can hold it without aliasing surprises.
     Fields are the union of what every provider can feasibly
-    expose — providers that do not have a field (e.g. RunPod has
+    expose; providers that do not have a field (e.g. RunPod has
     no ``image_uuid``) leave it empty.
+
+    For the CLI's instance listing, ``gpu_model`` and
+    ``cost_per_hour`` provide the table data without the
+    orchestrator having to parse provider JSON.
     """
 
     provider: "Provider"
     instance_id: str
-    image_uuid: str
     label: str
     state: str
+    image_uuid: str = ""           # Vast.ai: Docker image reference
+    ownership_key: str = ""        # Generic: any provider's ownership token
+    gpu_model: str = ""
+    cost_per_hour: float = 0.0
     started_at: float = 0.0
 
 
@@ -501,26 +713,46 @@ class InstanceCandidate:
 class CleanupResult:
     """Outcome of ``policy.destroy``.
 
-    Exactly one of ``destroyed`` (True) or ``refusal`` is set.
-    ``error`` is non-empty on refusal or protocol failure, empty
-    on success. The v4 design does not return the v3
-    ``DestroyResult`` directly — the policy wraps the v3 verdict
-    in a tighter one-of shape for the orchestrator.
+    Exactly one of ``verdict`` (CleanupVerdict) or ``refusal``
+    (CleanupRefusal) is set — never both, never neither. ``error``
+    is non-empty on every non-DESTROYED outcome (it carries the
+    structured diagnostic context); ``error`` is empty on
+    DESTROYED (success has no error).
+
+    The cleanup policy wraps the v3 ``DestroyResult`` (which has
+    ``verdict: DestroyVerdict`` + ``refusal: DestroyRefusal``)
+    in this tighter shape for the orchestrator.
     """
 
-    destroyed: bool = False
+    verdict: Optional[CleanupVerdict] = None
     refusal: Optional[CleanupRefusal] = None
     error: str = ""
 
     def __post_init__(self) -> None:
-        if self.destroyed and self.refusal is not None:
-            msg = "CleanupResult: destroyed=True and refusal=... are mutually exclusive"
-            raise ValueError(msg)
-        if not self.destroyed and self.refusal is None and not self.error:
-            msg = "CleanupResult: refusal=None requires either destroyed=True or error set"
-            raise ValueError(msg)
+        if (self.verdict is None) == (self.refusal is None):
+            raise ValueError(
+                "CleanupResult: exactly one of verdict or refusal must be set"
+            )
+        if self.verdict == CleanupVerdict.DESTROYED:
+            if self.error:
+                raise ValueError(
+                    "CleanupResult.DESTROYED must have empty error"
+                )
+        elif not self.error:
+            ident = (
+                self.verdict.value
+                if self.verdict is not None
+                else self.refusal.value
+            )
+            raise ValueError(
+                f"CleanupResult: {ident} must have non-empty error"
+            )
+```
 
+## `ProviderCleanupPolicy` shape
 
+```python
+# src/vastai_gpu_runner/cleanup_policy.py (policy class)
 @dataclass(frozen=True, kw_only=True)
 class ProviderCleanupPolicy:
     """Per-provider cleanup contract.
@@ -536,11 +768,13 @@ class ProviderCleanupPolicy:
             cleanup adapter both call ``ownership.matches(image_ref)``.
         list_instances_fn: Callable that returns a complete
             ``list[InstanceCandidate]``. Wired by the adapter.
+            The factory may wrap the provider's list helper with
+            the EXPLICITLY_DISABLED short-circuit.
         destroy_fn: Callable that takes one ``InstanceCandidate``,
-            applies the eligibility / ownership / credential /
-            hostile checks authoritatively, and returns a
-            ``CleanupResult``. The factory wires the v3
-            ``destroy_vastai_instance`` (with CLI fallback) here.
+            applies the eligibility / ownership / credential
+            checks authoritatively, and returns a ``CleanupResult``.
+            The factory wires the v3 ``destroy_vastai_instance``
+            (with CLI fallback) here.
 
     Why two callbacks (list + destroy) and not one: the
     orchestrator's outer loop separates enumeration from
@@ -559,6 +793,8 @@ class ProviderCleanupPolicy:
 
         The orchestrator's ``_sweep_zombies`` calls this once per
         sweep. Failures are caught and logged by the orchestrator.
+        The provider factory may wrap the underlying helper with
+        the EXPLICITLY_DISABLED short-circuit.
         """
         try:
             return self.list_instances_fn()
@@ -570,18 +806,21 @@ class ProviderCleanupPolicy:
         """Run the per-provider destroy on one candidate.
 
         Authoritative gate: this method re-validates the
-        candidate's ownership, eligibility, and credential state
-        on every call. The orchestrator must call this for every
-        label-matching, untracked candidate so refusals are
-        observable and loggable.
+        candidate's provider identity (PROVIDER_MISMATCH refusal)
+        on every call, then delegates to ``destroy_fn`` which
+        applies eligibility / ownership / credential checks.
 
         Never raises. The orchestrator must be able to log the
         result and continue to the next candidate.
         """
         if candidate.provider != self.provider:
             return CleanupResult(
-                refusal=CleanupRefusal.UNOWNED,
-                error=f"provider mismatch: {candidate.provider} != {self.provider}",
+                refusal=CleanupRefusal.PROVIDER_MISMATCH,
+                error=(
+                    f"candidate {candidate.instance_id!r} belongs to "
+                    f"provider {candidate.provider.value!r}; cleanup "
+                    f"policy expects {self.provider.value!r}"
+                ),
             )
         try:
             return self.destroy_fn(candidate)
@@ -591,15 +830,17 @@ class ProviderCleanupPolicy:
                 candidate.instance_id,
                 exc,
             )
-            return CleanupResult(error=str(exc))
+            return CleanupResult(
+                verdict=CleanupVerdict.UNKNOWN,
+                error=str(exc),
+            )
 ```
 
 ## `build_vastai_cleanup_policy` shape
 
 The provider-owned factory. This is the only place that combines
 v3's `destroy_vastai_instance` with the v4 policy. It lives in
-`providers/vastai.py` (not `cleanup_policy.py`) so the core module
-never imports provider adapters.
+`providers/vastai.py` so the core module has no provider imports.
 
 ```python
 # src/vastai_gpu_runner/providers/vastai.py
@@ -608,23 +849,24 @@ def build_vastai_cleanup_policy(
 ) -> ProviderCleanupPolicy:
     """Build a Vast.ai cleanup policy from the canonical config.
 
-    The canonical config (the same `VastaiProviderConfig` passed
-    to `VastaiRunner.from_config`) is the source of truth for the
+    The canonical config (the same ``VastaiProviderConfig`` passed
+    to ``VastaiRunner.from_config``) is the source of truth for the
     ownership policy, the credential resolution, and the deployment
     identity. Reading from the same source guarantees the destroy
     ownership guard and the runner's ownership guard cannot drift.
 
-    The wired ``destroy_fn`` enforces the v3 contract:
-    - ``EXPLICITLY_DISABLED`` → ``CleanupResult(refusal=CREDENTIALS_DISABLED)``
-      without invoking CLI enumeration.
-    - ``AVAILABLE`` → v3 ``destroy_vastai_instance`` with the
-      REST bearer key.
-    - ``ABSENT`` → v3 CLI fallback (with CLI ownership verification,
-      per v3 contract).
+    The wired ``list_instances_fn`` enforces the v3 contract:
+    EXPLICITLY_DISABLED credentials return [] without invoking
+    CLI enumeration (no API key, no CLI fallback — fail-closed).
+
+    The wired ``destroy_fn`` translates the v3 DestroyResult into
+    the v4 CleanupResult, preserving all four verdicts and all
+    three refusals.
     """
     from vastai_gpu_runner.cleanup_policy import (
         CleanupRefusal,
         CleanupResult,
+        CleanupVerdict,
         OwnershipPolicy,
         ProviderCleanupPolicy,
     )
@@ -633,47 +875,77 @@ def build_vastai_cleanup_policy(
         DestroyVerdict,
     )
     from vastai_gpu_runner.providers.destroy_adapters.vastai import (
-        VASTAI_POLICY,
         destroy_vastai_instance,
     )
 
+    def _list_instances() -> list[InstanceCandidate]:
+        # v3 contract: EXPLICITLY_DISABLED short-circuits before
+        # CLI enumeration. The CLI fallback path uses file
+        # credentials which would silently bypass the explicit
+        # disable — fail-closed.
+        if canonical.credentials.state == CredentialState.EXPLICITLY_DISABLED:
+            logger.warning(
+                "Zombie sweep disabled: VASTAI_API_KEY is explicitly empty; "
+                "provider enumeration was not attempted."
+            )
+            return []
+        return list_vastai_instances()
+
     def _destroy(candidate: InstanceCandidate) -> CleanupResult:
-        # Pre-protocol refusal: credentials explicitly disabled.
-        # No enumeration, no CLI fallback — v3 contract.
-        if canonical.credentials.state == CredentialResolution.EXPLICITLY_DISABLED:
+        # Authoritative eligibility check (per v4 CONCERN 9).
+        if candidate.state not in VASTAI_ELIGIBLE_STATES:
+            return CleanupResult(
+                refusal=CleanupRefusal.INELIGIBLE_STATE,
+                error=(
+                    f"state {candidate.state!r} not in "
+                    f"VASTAI_ELIGIBLE_STATES={set(VASTAI_ELIGIBLE_STATES)!r}"
+                ),
+            )
+        # CREDENTIALS_DISABLED: refuse without provider calls.
+        if canonical.credentials.state == CredentialState.EXPLICITLY_DISABLED:
             return CleanupResult(
                 refusal=CleanupRefusal.CREDENTIALS_DISABLED,
                 error="VASTAI_API_KEY explicitly empty",
             )
-        # The v3 destroy_vastai_instance handles the ownership
-        # guard + the belt-and-suspenders protocol. Translate its
-        # DestroyResult into a CleanupResult.
+        # Delegate to v3 adapter with the canonical ownership + credentials.
         result = destroy_vastai_instance(
             candidate.instance_id,
-            allowed_images=(
-                frozenset(canonical.ownership.owned_images)
-                if canonical.ownership.owned_images is not None
-                else None
-            ),
+            ownership=canonical.ownership,
+            credentials=canonical.credentials,
         )
-        if result.refusal == DestroyRefusal.OWNERSHIP:
+        # Translate refusals first.
+        if result.refusal is not None:
+            mapping = {
+                DestroyRefusal.OWNERSHIP: CleanupRefusal.OWNERSHIP,
+                DestroyRefusal.NO_CREDENTIALS: CleanupRefusal.NO_CREDENTIALS,
+                DestroyRefusal.CREDENTIALS_DISABLED: CleanupRefusal.CREDENTIALS_DISABLED,
+            }
             return CleanupResult(
-                refusal=CleanupRefusal.UNOWNED,
+                refusal=mapping[result.refusal],
                 error=result.error,
             )
-        if result.refusal == DestroyRefusal.NO_CREDENTIALS:
-            return CleanupResult(
-                refusal=CleanupRefusal.NO_CREDENTIALS,
-                error=result.error,
-            )
+        # Translate verdicts exhaustively.
         if result.verdict == DestroyVerdict.DESTROYED:
-            return CleanupResult(destroyed=True)
-        return CleanupResult(error=result.error or "destroy protocol did not confirm")
+            return CleanupResult(verdict=CleanupVerdict.DESTROYED)
+        if result.verdict == DestroyVerdict.CLI_ATTEMPTED:
+            return CleanupResult(
+                verdict=CleanupVerdict.CLI_ATTEMPTED,
+                error=result.error,
+            )
+        if result.verdict == DestroyVerdict.LEAKED:
+            return CleanupResult(
+                verdict=CleanupVerdict.LEAKED,
+                error=result.error,
+            )
+        return CleanupResult(
+            verdict=CleanupVerdict.UNKNOWN,
+            error=result.error or "v3 adapter returned no verdict",
+        )
 
     return ProviderCleanupPolicy(
-        provider=canonical.docker_image and Provider.VASTAI or Provider.VASTAI,
+        provider=Provider.VASTAI,
         ownership=canonical.ownership,
-        list_instances_fn=list_vastai_instances,
+        list_instances_fn=_list_instances,
         destroy_fn=_destroy,
     )
 ```
@@ -681,8 +953,7 @@ def build_vastai_cleanup_policy(
 ## Orchestrator wiring
 
 The orchestrator's `_sweep_zombies` becomes policy-driven end-to-end.
-The provider-specific destroy call is gone; the orchestrator only
-knows the policy.
+The orchestrator logs every non-`DESTROYED` outcome.
 
 ```python
 # src/vastai_gpu_runner/batch.py (changes to _sweep_zombies)
@@ -690,17 +961,18 @@ def _sweep_zombies(self) -> int:
     """Destroy orphaned instances not tracked by live_runners.
 
     Routes through the cleanup policy:
-    1. Enumerate instances via ``policy.list_instances()``.
+    1. Enumerate instances via ``policy.list_instances()`` (which
+       may short-circuit on EXPLICITLY_DISABLED).
     2. Filter by label prefix (orchestrator's per-batch scope).
     3. Exclude tracked IDs (the existing semantics).
     4. For every remaining candidate, call ``policy.destroy(candidate)``.
-    5. Count ``destroyed == True`` outcomes.
-    6. Log refusals for visibility.
+    5. Count ``verdict == DESTROYED`` outcomes.
+    6. Log every non-DESTROYED outcome distinctly.
 
     The orchestrator does NOT branch on Provider, does NOT import
     provider modules, and does NOT call any provider-specific
-    destroy function. The policy owns the eligibility /
-    ownership / credential / hostile decisions.
+    destroy function. The policy owns the eligibility / ownership
+    / credential decisions.
     """
     with self._state_lock:
         tracked_ids = {
@@ -708,23 +980,47 @@ def _sweep_zombies(self) -> int:
         }
     candidates = self._cleanup_policy.list_instances()
     killed = 0
+    cli_attempted = 0
+    leaked = 0
+    unknown = 0
     for candidate in candidates:
         if not candidate.label.startswith(self._label_prefix):
             continue
         if candidate.instance_id in tracked_ids:
             continue
         result = self._cleanup_policy.destroy(candidate)
-        if result.destroyed:
+        if result.verdict == CleanupVerdict.DESTROYED:
             killed += 1
-        elif result.refusal is not None:
-            logger.info(
-                "Zombie sweep: %s refused (%s): %s",
-                candidate.instance_id,
-                result.refusal.value,
-                result.error,
-            )
+            continue
+        # Log every non-DESTROYED outcome distinctly.
+        kind = (
+            result.verdict.value
+            if result.verdict is not None
+            else result.refusal.value
+        )
+        logger.info(
+            "Zombie sweep: %s outcome=%s: %s",
+            candidate.instance_id,
+            kind,
+            result.error,
+        )
+        if result.verdict == CleanupVerdict.CLI_ATTEMPTED:
+            cli_attempted += 1
+        elif result.verdict == CleanupVerdict.LEAKED:
+            leaked += 1
+        elif result.verdict == CleanupVerdict.UNKNOWN:
+            unknown += 1
     if killed:
         logger.info("Zombie sweep: destroyed %d instance(s)", killed)
+    if cli_attempted:
+        logger.info(
+            "Zombie sweep: %d CLI fallback(s) attempted (destruction not confirmed)",
+            cli_attempted,
+        )
+    if leaked:
+        logger.warning("Zombie sweep: %d LEAKED instance(s) — manual review needed", leaked)
+    if unknown:
+        logger.warning("Zombie sweep: %d UNKNOWN outcome(s)", unknown)
     return killed
 ```
 
@@ -750,6 +1046,7 @@ def batch(
 ) -> None:
     """Run a batch of cloud GPU units under the user's project image."""
     from dataclasses import replace
+    from vastai_gpu_runner.cleanup_policy import OwnershipPolicy
     from vastai_gpu_runner.providers.vastai import (
         VastaiProviderConfig,
         VastaiRunner,
@@ -780,117 +1077,228 @@ def batch(
     orch.run()
 ```
 
+The existing `cli.py:cleanup` and `cli.py:instances` commands
+migrate to use the new API in migration step 5:
+
+```python
+# src/vastai_gpu_runner/cli.py (cleanup command)
+@app.command()
+def cleanup(
+    label_prefix: Annotated[str, typer.Option("--label", "-l")] = ...,
+    owned_images: Annotated[
+        str | None,
+        typer.Option(
+            "--owned-images",
+            "--allowed-images",  # back-compat alias (kept canonical)
+            help="Comma-separated Docker images owned by this project",
+        ),
+    ] = None,
+    dry_run: Annotated[bool, typer.Option("--dry-run")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
+) -> None:
+    """Destroy orphaned Vast.ai instances matching a label prefix."""
+    _setup_logging(verbose)
+    from rich.console import Console
+    from vastai_gpu_runner.cleanup_policy import (
+        CleanupVerdict,
+        OwnershipPolicy,
+    )
+    from vastai_gpu_runner.providers.vastai import (
+        VastaiProviderConfig,
+        build_vastai_cleanup_policy,
+    )
+
+    console = Console()
+    ownership = (
+        OwnershipPolicy(owned_images=frozenset(owned_images.split(",")))
+        if owned_images
+        else OwnershipPolicy()
+    )
+    config = VastaiProviderConfig.from_env(owned_images=ownership.owned_images)
+    cleanup_policy = build_vastai_cleanup_policy(config)
+
+    candidates = cleanup_policy.list_instances()
+    matches = [c for c in candidates if c.label.startswith(label_prefix)]
+    if not matches:
+        console.print(f"No instances matching label prefix '{label_prefix}'.")
+        return
+
+    console.print(f"Found {len(matches)} instance(s) matching '{label_prefix}':")
+    for c in matches:
+        console.print(
+            f"  {c.instance_id}: {c.gpu_model or '?'} "
+            f"status={c.state or '?'} label={c.label}"
+        )
+
+    if dry_run:
+        console.print("\n[yellow]Dry run — no instances destroyed.[/yellow]")
+        return
+
+    if not typer.confirm(f"\nDestroy {len(matches)} instance(s)?"):
+        console.print("Aborted.")
+        raise typer.Exit(0)
+
+    destroyed = 0
+    for c in matches:
+        result = cleanup_policy.destroy(c)
+        if result.verdict == CleanupVerdict.DESTROYED:
+            console.print(f"  [green]Destroyed[/green] {c.instance_id}")
+            destroyed += 1
+        else:
+            kind = (
+                result.verdict.value
+                if result.verdict is not None
+                else result.refusal.value
+            )
+            console.print(f"  [red]{kind}[/red] {c.instance_id}: {result.error}")
+    console.print(f"\nDestroyed {destroyed}/{len(matches)} instance(s).")
+```
+
 ## Migration checklist
 
-Seven steps. The order is the ChatGPT 5th-pass recommendation
+Seven steps. The order is the ChatGPT 5th + 6th pass recommendation
 (canonical types first, adapter before orchestrator, audit before
 deletion). Each step is independently testable but the rollout
 lands as one PR because the intermediate states are not stable.
 
 1. **Add canonical credential + ownership-policy types + invariants + contract tests.**
-   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)`).
-   - `providers/destroy_adapters/vastai.py:CredentialResolution` + `CredentialResolutionResult` (v3 prerequisite — may already exist if v3 is implemented).
-   - Property tests: `OwnershipPolicy.matches` is reflexive (the owned image matches itself); tag-insensitive (`:1.0` and `:latest` match when the repository is owned); `None` opts out (every image matches); empty set rejects everything (fail-closed); different registry prefixes do not match (`registry:5000/myorg/app` ≠ `registry-malicious/myorg/app`).
+   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with the v3 `_repository` helper).
+   - `providers/destroy_adapters/vastai.py:CredentialState` + `CredentialResolution` (v3 prerequisite — may already exist if v3 is implemented).
+   - Property tests: `OwnershipPolicy.matches` is reflexive (the owned image matches itself); tag-insensitive (`:1.0` and `:latest` match when the repository is owned); `None` opts out (every image matches); empty set rejects everything (fail-closed); different registry prefixes do not match (`registry:5000/myorg/app` ≠ `registry-malicious/myorg/app`); sha256 digests match by repository; malformed references (multiple `@`, multiple `:`) return `False`.
    - `CredentialResolution` invariants: `AVAILABLE` requires non-empty pre-stripped key; `ABSENT` and `EXPLICITLY_DISABLED` require empty key.
 
 2. **Add `VastaiProviderConfig` + `VastaiRunner.from_config` + constructor parity.**
    - `providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership` + `credentials` + `docker_image`).
-   - `__post_init__` invariant: `docker_image ∈ ownership.owned_images` unless ownership is disabled.
-   - `VastaiRunner.from_config(config)` classmethod. Constructor parity test: `VastaiRunner(allowed_images=frozenset({img}), docker_image=img, ...)` and `VastaiRunner.from_config(VastaiProviderConfig(docker_image=img, ownership=OwnershipPolicy(owned_images=frozenset({img})), ...))` produce equivalent attribute values for the runner.
-   - `VastaiProviderConfig.from_env()` reads the v3 `read_vastai_api_key` into `credentials`.
+   - `__post_init__` invariants: `docker_image` non-empty + pre-stripped; `docker_image ∈ ownership.owned_images` unless ownership is disabled.
+   - `VastaiRunner.from_config(config)` classmethod. Constructor parity test: `VastaiRunner(allowed_images=frozenset({img}), docker_image=img, ...)` (deprecated path) and `VastaiRunner.from_config(VastaiProviderConfig(docker_image=img, ownership=OwnershipPolicy(owned_images=frozenset({img})), ...))` produce equivalent `ownership` attribute values.
+   - `VastaiRunner.__init__` adds `ownership: OwnershipPolicy | None` parameter; `allowed_images` becomes a deprecated alias (emits `DeprecationWarning` when used).
+   - `verify_instance_ownership(instance_id, *, ownership=OwnershipPolicy)` — replaces the raw `allowed_images` set check with `ownership.matches(image_uuid)`. The `_image_is_allowed` helper is **deleted**.
+   - `VastaiProviderConfig.from_env()` reads the v3 `read_vastai_api_key()` into `credentials`.
 
 3. **Add Vast.ai cleanup adapter (enumeration + authoritative destroy + CLI fallback).**
    - `providers/vastai.py:list_vastai_instances()` (returns `list[InstanceCandidate]`, empty list on API failure).
-   - `providers/vastai.py:build_vastai_cleanup_policy(config)` (wires `list_instances_fn` + `destroy_fn` from the v3 adapter).
+   - `providers/vastai.py:VASTAI_ELIGIBLE_STATES` module constant (frozenset of states the destroy path can act on).
+   - `providers/vastai.py:build_vastai_cleanup_policy(config)` (wires `list_instances_fn` + `destroy_fn`).
+   - The factory wraps `list_vastai_instances` with the EXPLICITLY_DISABLED short-circuit.
+   - The factory's `_destroy` performs the eligibility check (`INELIGIBLE_STATE`) before delegating to `destroy_vastai_instance`.
    - Adapter tests:
-     - `EXPLICITLY_DISABLED` path: `destroy_fn` returns `refusal=CREDENTIALS_DISABLED` without invoking `vastai_cmd` (mock and assert).
-     - `AVAILABLE` path: `destroy_fn` calls `destroy_vastai_instance` with the loaded key; `verdict=DESTROYED` → `CleanupResult(destroyed=True)`.
-     - `ABSENT` path: `destroy_fn` falls through to CLI fallback (per v3 contract); `verdict=DESTROYED` → `CleanupResult(destroyed=True)`.
-     - `refusal=OWNERSHIP` translation → `CleanupResult(refusal=UNOWNED)`.
-     - `refusal=NO_CREDENTIALS` translation → `CleanupResult(refusal=NO_CREDENTIALS)`.
+     - **disabled-before-enumeration**: config with `credentials=EXPLICITLY_DISABLED`; `policy.list_instances()` returns `[]` without invoking `vastai_cmd` (mock and assert `vastai_cmd` was not called).
+     - `AVAILABLE` path: `destroy_fn` calls `destroy_vastai_instance` with the loaded key; `verdict=DESTROYED` → `CleanupResult(verdict=DESTROYED)`.
+     - `ABSENT` path: `destroy_fn` falls through to CLI fallback (per v3 contract); `verdict=CLI_ATTEMPTED` → `CleanupResult(verdict=CLI_ATTEMPTED, error=...)`.
+     - `verdict=OWNERSHIP` translation → `CleanupResult(refusal=OWNERSHIP)`.
+     - `verdict=NO_CREDENTIALS` translation → `CleanupResult(refusal=NO_CREDENTIALS)`.
+     - `verdict=CREDENTIALS_DISABLED` translation → `CleanupResult(refusal=CREDENTIALS_DISABLED)`.
+     - `verdict=LEAKED` translation → `CleanupResult(verdict=LEAKED, error=...)`.
+     - `verdict=UNKNOWN` translation → `CleanupResult(verdict=UNKNOWN, error=...)`.
+     - `INELIGIBLE_STATE` path: candidate.state not in `VASTAI_ELIGIBLE_STATES` → `CleanupResult(refusal=INELIGIBLE_STATE, error=...)` without invoking `destroy_vastai_instance`.
      - `list_vastai_instances()` returns `[]` on `RuntimeError` and `JSONDecodeError` (does not raise).
 
 4. **Add orchestrator support behind a fail-closed compatibility path.**
    - `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required).
-   - `_sweep_zombies` becomes policy-driven (the v4.2 code shape above).
+   - `_sweep_zombies` becomes policy-driven (the v4.3 code shape above).
    - Orchestrator tests:
      - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once.
      - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate.
-     - `_sweep_zombies` counts only `destroyed=True` outcomes.
-     - `_sweep_zombies` logs refusals (no exception, no crash).
-     - `_sweep_zombies` continues on `destroy_fn` exceptions.
-     - `_sweep_zombies` does NOT branch on `Provider` (verified by mock introspection: swapping the policy for a RunPod-shaped policy would still work).
+     - `_sweep_zombies` counts only `verdict=DESTROYED` outcomes.
+     - `_sweep_zombies` logs `CLI_ATTEMPTED`, `LEAKED`, `UNKNOWN`, and every refusal distinctly.
+     - `_sweep_zombies` continues on `destroy_fn` exceptions (they return `verdict=UNKNOWN`).
+     - `_sweep_zombies` does NOT branch on `Provider` (verified by `inspect.getsource` — `batch.py` should not contain `from vastai_gpu_runner.providers.vastai import` outside the docstring).
 
 5. **Update every composition root, subclass, and existing CLI command.**
-   - `cli.py:cli` (composition root): build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy`.
-   - `cli.py:cleanup` (existing CLI command): migrate to use `build_vastai_cleanup_policy` + `policy.destroy`. No more direct `vastai_cmd(["show", "instances", "--raw"])` parsing.
-   - `cli.py:instances` (existing CLI command): migrate to use `list_vastai_instances()` for the table. The `--allowed-images` flag becomes `--owned-images` (CLI help text updated to point at `OwnershipPolicy`).
+   - `cli.py:batch` (composition root): build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy`.
+   - `cli.py:cleanup` (existing CLI command): migrate to use `build_vastai_cleanup_policy` + `policy.list_instances()` + `policy.destroy()`. No more direct `vastai_cmd(["show", "instances", "--raw"])` parsing.
+   - `cli.py:instances` (existing CLI command): migrate to use `list_vastai_instances()` for the table. The `--allowed-images` flag is preserved as canonical; `--owned-images` is added as a documented alias (back-compat for any external scripts that already use `--owned-images`).
    - `BatchOrchestrator` subclasses (consumer code): existing `BatchOrchestrator(...)` calls now require `cleanup_policy`. Update each subclass's composition.
    - Test fixtures and conftest: `VastaiProviderConfig` factory fixture for tests.
 
 6. **Add integration tests.**
    - `tests/integration/test_cleanup_policy_integration.py` (or equivalent):
-     - **disabled-before-enumeration**: config with `credentials=EXPLICITLY_DISABLED`; `policy.destroy(candidate)` returns `CREDENTIALS_DISABLED` even when the candidate's image is owned. `list_instances()` is called but `destroy_fn` is not (no API key passed).
-     - **absent-credential CLI fallback**: config with `credentials=ABSENT`; `policy.destroy(candidate)` falls through to CLI fallback path and the v3 `destroy_vastai_instance` is invoked with `api_key=None` (CLI path).
-     - **empty ownership set**: config with `ownership=OwnershipPolicy(owned_images=frozenset())`; `policy.destroy(candidate)` returns `UNOWNED` for every candidate (fail-closed).
-     - **provider mismatch**: candidate with `provider=Provider.RUNPOD` is passed to a `Provider.VASTAI` policy; returns `UNOWNED` with `provider mismatch` error.
+     - **disabled-before-enumeration**: config with `credentials=EXPLICITLY_DISABLED`; `policy.list_instances()` returns `[]`; `vastai_cmd` was not called (verified by mock call count).
+     - **absent-credential CLI fallback**: config with `credentials=ABSENT`; `policy.destroy(candidate)` falls through to CLI fallback path; the v3 `destroy_vastai_instance` is invoked with `credentials=None` (the CLI fallback path); `verdict=CLI_ATTEMPTED` translates to `CleanupResult(verdict=CLI_ATTEMPTED, error=...)`.
+     - **empty ownership set**: config with `ownership=OwnershipPolicy(owned_images=frozenset())`; `policy.destroy(candidate)` returns `OWNERSHIP` for every candidate (fail-closed).
+     - **provider mismatch**: candidate with `provider=Provider.RUNPOD` passed to a `Provider.VASTAI` policy; returns `PROVIDER_MISMATCH` with the operator-friendly diagnostic.
      - **enumeration failure**: `list_vastai_instances()` raises on `RuntimeError`; `policy.list_instances()` returns `[]` (the policy catches the exception).
-   - The integration tests use mocks; the CLI fallback path is tested with the v3 mock infrastructure.
+     - **ineligible state**: candidate with `state="destroyed"` passed to the Vast.ai policy; returns `INELIGIBLE_STATE` without invoking `destroy_vastai_instance`.
+     - **non-DESTROYED logging**: orchestrator logs `CLI_ATTEMPTED`, `LEAKED`, `UNKNOWN`, and every refusal distinctly (verified by `caplog`).
 
 7. **Delete legacy sweep + duplicated helpers after a repository-wide caller audit.**
    - `audit_caller_sites.sh` (run before the deletion): grep for any external caller of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use). Update external callers.
-   - Delete `orchestrator.sweep_zombie_instances` (already deferred to v3; v4.2 reaffirms).
+   - Delete `orchestrator.sweep_zombie_instances` (already deferred to v3; v4.3 reaffirms).
    - Delete `orchestrator.load_vastai_api_key` (v3 deferral reaffirmed).
+   - Delete `providers/vastai.py:_image_is_allowed` (replaced by `OwnershipPolicy.matches()`).
    - Delete direct `vastai_cmd(["show", "instances", "--raw"])` parsing in `cli.py:cleanup` and `cli.py:instances`.
    - Update `tests/test_orchestrator.py` and `tests/test_batch.py` to mock `cleanup_policy.list_instances` and `cleanup_policy.destroy` instead of `sweep_zombie_instances`.
 
 ## Test plan
 
 - `tests/test_cleanup_policy.py` — unit tests:
+  - `_repository`:
+    - `myorg/app:1.0` → `myorg/app`
+    - `myorg/app:latest` → `myorg/app`
+    - `myorg/app@sha256:abc...` → `myorg/app` (digest stripped)
+    - `ubuntu:22.04` → `ubuntu` (no slash)
+    - `registry:5000/myorg/app:1.0` → `registry:5000/myorg/app` (registry preserved)
+    - `registry-malicious/myorg/app:1.0` → `registry-malicious/myorg/app`
+    - `myorg/app:1.0:malicious` → `""` (malformed multi-tag)
+    - `myorg/app@sha1:abc@sha256:def` → `""` (malformed multi-digest)
+    - `""` → `""` (empty)
+    - `"   "` → `""` (whitespace only)
   - `OwnershipPolicy.matches`:
-    - `None` ownership: every image matches (including the empty string)
+    - `None` ownership: every image matches (including the empty string and malformed references)
     - Non-empty set: exact reference matches
     - Non-empty set: tag-insensitive repository matches (`:1.0` and `:latest` both match)
+    - Non-empty set: sha256 digest matches by repository
     - Non-empty set: different registry prefix does NOT match
-    - Empty set: no image matches (fail-closed)
-    - Image `myorg/app:1.0` does NOT match `myorg/app-malicious:latest`
-    - `registry:5000/myorg/app:1.0` does NOT match `registry-malicious/myorg/app:1.0`
+    - Non-empty set: image `myorg/app:1.0` does NOT match `myorg/app-malicious:latest`
+    - Non-empty set: `registry:5000/myorg/app:1.0` does NOT match `registry-malicious/myorg/app:1.0`
+    - Empty set: no image matches (fail-closed), including for the empty string and malformed references
+    - `_normalised` is precomputed and frozen: `matches` is O(1)
   - `ProviderCleanupPolicy.list_instances`:
     - Returns the wired list
     - Catches and returns `[]` on `list_instances_fn` exception
   - `ProviderCleanupPolicy.destroy`:
-    - Provider mismatch returns `UNOWNED` with `provider mismatch` error
-    - Catches `destroy_fn` exceptions and returns `CleanupResult(error=...)`
+    - Provider mismatch returns `PROVIDER_MISMATCH` with the operator-friendly error
+    - Catches `destroy_fn` exceptions and returns `CleanupResult(verdict=UNKNOWN, error=...)`
     - Delegates to `destroy_fn` on the happy path
   - `CleanupResult` invariants:
-    - `destroyed=True` + `refusal=...` raises `ValueError`
-    - `destroyed=False` + `refusal=None` + `error=""` raises `ValueError`
+    - `verdict=DESTROYED` + non-empty `error` raises `ValueError`
+    - `verdict=CLI_ATTEMPTED` + empty `error` raises `ValueError`
+    - `refusal=...` + empty `error` raises `ValueError`
+    - Both `verdict` and `refusal` set raises `ValueError`
+    - Neither `verdict` nor `refusal` set raises `ValueError`
   - `VastaiProviderConfig` invariants:
+    - Empty `docker_image` raises `ValueError`
+    - Whitespace-only `docker_image` raises `ValueError`
     - `docker_image` not in `owned_images` raises `ValueError`
     - `docker_image` in `owned_images` is valid
     - `ownership.owned_images is None` (disabled) accepts any `docker_image`
+    - `from_env(docker_image="")` raises `ValueError` (explicit empty is not None)
+    - `from_env(docker_image=None)` returns the default image
 - `tests/test_providers_vastai.py` — adapter tests:
-  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig`
-  - `list_vastai_instances` returns `list[InstanceCandidate]`
+  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig` (constructor parity)
+  - `VastaiRunner(allowed_images=frozenset({img}))` (deprecated path) emits `DeprecationWarning` and builds an equivalent `OwnershipPolicy`
+  - `verify_instance_ownership` uses `OwnershipPolicy.matches()`
+  - `list_vastai_instances` returns `list[InstanceCandidate]` with `gpu_model` + `cost_per_hour` populated
   - `list_vastai_instances` returns `[]` on API error (does not raise)
-  - `build_vastai_cleanup_policy` wires the v3 adapter correctly
+  - `build_vastai_cleanup_policy` wires the v3 adapter correctly (all 4 verdicts, all 3 refusals, `INELIGIBLE_STATE`, `PROVIDER_MISMATCH`, EXPLICITLY_DISABLED short-circuit)
 - `tests/test_batch.py` — orchestrator wiring:
   - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once
   - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate
-  - `_sweep_zombies` counts only `destroyed=True` outcomes
-  - `_sweep_zombies` logs refusals (no exception, no crash)
+  - `_sweep_zombies` counts only `verdict=DESTROYED` outcomes
+  - `_sweep_zombies` logs `CLI_ATTEMPTED`, `LEAKED`, `UNKNOWN`, and every refusal distinctly (`caplog`)
   - `_sweep_zombies` continues on `destroy_fn` exceptions
-  - `_sweep_zombies` does NOT import provider modules (verified by `inspect.getsource` — should not show `from vastai_gpu_runner.providers.vastai import` in `batch.py`)
-- `tests/integration/test_cleanup_policy_integration.py` — integration tests (six scenarios from step 6 above).
-- Existing tests for `verify_instance_ownership` and `VastaiRunner.destroy_instance` are unchanged (the runner's ownership guard is preserved; only the policy owner changes).
+  - `_sweep_zombies` does NOT import provider modules (verified by `inspect.getsource`)
+- `tests/integration/test_cleanup_policy_integration.py` — integration tests (seven scenarios from step 6 above).
+- Existing tests for `verify_instance_ownership` and `VastaiRunner.destroy_instance` are updated to use `OwnershipPolicy` (the v4 amendment).
 
 ## Backwards compatibility
 
 The `VastaiRunner.__init__(allowed_images=..., docker_image=..., ...)`
-constructor is preserved. Existing callers (scripts, unit tests,
-third-party consumers) that build the runner by hand keep working.
-The CLI's new `batch` subcommand is the recommended path; the old
-programmatic path requires a `cleanup_policy` to be supplied.
+constructor is preserved as a deprecated back-compat path. Existing
+callers (scripts, unit tests, third-party consumers) that build the
+runner by hand keep working but emit a `DeprecationWarning`. The
+CLI's new `batch` subcommand uses `from_config`; the old programmatic
+path requires a `cleanup_policy` to be supplied.
 
 The `orchestrator.py:sweep_zombie_instances` function is deleted in
 v4 step 7. The v3 implementation already migrated its callers
@@ -900,9 +1308,10 @@ last direct caller. Any external code that imported
 `ProviderCleanupPolicy` and call `policy.destroy(candidate)`.
 
 The `cli.py:cleanup` and `cli.py:instances` commands are refactored
-in v4 step 5. The `--allowed-images` flag is renamed to
-`--owned-images` (with a deprecation cycle: the old flag is
-accepted for one minor version and emits a warning).
+in v4 step 5. The `--allowed-images` flag is preserved as canonical;
+`--owned-images` is added as a documented alias. The rename is
+deferred to a separate CLI compatibility change (no removal of
+`--allowed-images` in this PR).
 
 ## Out of scope
 
@@ -914,12 +1323,9 @@ accepted for one minor version and emits a warning).
   provider-agnostic from day one.
 - **Hostile detection.** The v4 first draft had a `hostile_check`
   boolean + threshold; the 5th-pass review flagged it as
-  semantically redundant (unowned candidates are refused
-  regardless of age). Hostile detection is deferred to a separate
-  audit stage that emits `AGED_UNOWNED` alerts without changing
-  the destroy decision. When the dispute workflow lands, the
-  hostile stage is added to the policy as a no-side-effect
-  classifier.
+  semantically redundant. The 6th-pass review reaffirmed the
+  removal. Hostile detection is deferred to a separate audit
+  stage that emits alerts without changing the destroy decision.
 - **Dispute webhook.** The dispute workflow is future work.
   YAGNI for now.
 - **Bulk-destroy optimisation.** The v4 sweep destroys one
@@ -933,13 +1339,12 @@ accepted for one minor version and emits a warning).
 
 ## Review process
 
-This is the second review pass on the v4 architecture. The first
-draft was reviewed by ChatGPT and returned 5 BLOCKERs and 7
-CONCERNs; this draft addresses all of them. The diff to the first
-draft is summarized in the "What changes vs the v4 first draft"
-section above.
+This is the third review pass on the v4 architecture. The first
+draft was rejected with 5 BLOCKERs and 7 CONCERNs. The second draft
+was rejected with 7 BLOCKERs, 2 CONCERNs, and 3 NITs. This third
+draft addresses every finding.
 
-The second review prompt for ChatGPT-with-GitHub-plugin:
+The third review prompt for ChatGPT-with-GitHub-plugin:
 
 > Review the v4 architecture design at PR #22 (file:
 > docs/architecture-v4-cleanup-policy.md) against the v3 design at
@@ -949,61 +1354,73 @@ The second review prompt for ChatGPT-with-GitHub-plugin:
 > resolves issue #19 (the ProviderCleanupPolicy follow-up).
 >
 > The first draft was rejected with 5 BLOCKERs and 7 CONCERNs.
-> Verify each finding is addressed:
+> The second draft was rejected with 7 BLOCKERs, 2 CONCERNs, and
+> 3 NITs. Verify each finding is addressed:
 >
-> 1. **BLOCKER 1 (dataclass field ordering)**: confirm
->    `ProviderCleanupPolicy` uses `@dataclass(frozen=True,
->    kw_only=True)` and all callbacks are keyword-only.
-> 2. **BLOCKER 2 (list_instances on the policy)**: confirm
->    `list_instances_fn` is added and `list_instances()` is a
->    public method.
-> 3. **BLOCKER 3 (is_candidate/destroy inconsistency)**: confirm
->    `destroy()` is authoritative and `is_candidate` was removed
->    from the orchestrator's call path.
-> 4. **BLOCKER 4 (hostile check)**: confirm the hostile check is
->    removed from the policy.
-> 5. **BLOCKER 5 (credential model)**: confirm
->    `CredentialResolution` (three-state) is used in
->    `VastaiProviderConfig` and `EXPLICITLY_DISABLED` short-
->    circuits before enumeration.
-> 6. **BLOCKER 6 (ownership semantics)**: confirm
->    `OwnershipPolicy.matches()` is introduced and consumed by
->    both the runner and the adapter; confirm the
->    `docker_image ∈ owned_images` invariant.
-> 7. **BLOCKER 7 (CLI discards from_env)**: confirm the CLI
->    uses `dataclasses.replace` instead of `from_env().__class__(...)`.
-> 8. **CONCERN 8 (provider factories in core)**: confirm the
->    Vast.ai factory is moved to `providers/vastai.py` and the
->    core module has no provider imports.
-> 9. **CONCERN 9 (state filter)**: confirm the state filter is
->    removed; `list_*_instances()` is complete enumeration;
->    `destroy()` applies eligibility authoritatively.
-> 10. **CONCERN 10 (CleanupResult invariants)**: confirm the
->     `__post_init__` invariants are added and the v3
->     `DestroyVerdict` enum is used.
-> 11. **CONCERN 11 (no-op RunPod adapter)**: confirm
->     `from_runpod_config` is removed.
-> 12. **CONCERN 12 (migration order)**: confirm the 7-step
->     checklist is reordered (canonical types first, adapter
->     before orchestrator, audit before deletion) and the
->     `cli.py:cleanup` and `cli.py:instances` commands are
->     addressed.
+> 1. **BLOCKER 1 (_repository broken)**: confirm `_repository` now
+>    strips digest, strips only the final tag separator (after
+>    the last `/`), preserves registry and port, and rejects
+>    malformed references.
+> 2. **BLOCKER 2 (runner/adapter don't consume OwnershipPolicy)**:
+>    confirm both call `OwnershipPolicy.matches()` and the v3
+>    `destroy_vastai_instance` accepts `ownership: OwnershipPolicy`.
+> 3. **BLOCKER 3 (v3 type names)**: confirm `CredentialState` (enum)
+>    and `CredentialResolution` (dataclass with `state` and `key`)
+>    are used.
+> 4. **BLOCKER 4 (EXPLICITLY_DISABLED before enumeration)**: confirm
+>    the factory wraps `list_vastai_instances` and the integration
+>    test asserts `vastai_cmd` is not called when credentials are
+>    disabled.
+> 5. **BLOCKER 5 (CLI fallback + DestroyResult translation)**: confirm
+>    the `_destroy` callback refuses EXPLICITLY_DISABLED without
+>    provider calls, uses canonical API key for REST, runs CLI fallback
+>    for ABSENT, returns `CLI_ATTEMPTED` after CLI command, translates
+>    all four v3 verdicts and all three v3 refusals.
+> 6. **BLOCKER 6 (docker_image invariant)**: confirm empty or
+>    whitespace-only `docker_image` raises `ValueError`.
+> 7. **BLOCKER 7 (undefined names)**: confirm `cleanup_policy.py`
+>    imports `logging` and `cli.py` imports `OwnershipPolicy`.
+> 8. **CONCERN 8 (CleanupResult invariants)**: confirm `verdict |
+>    refusal` is mutually exclusive and non-DESTROYED outcomes have
+>    non-empty `error`.
+> 9. **CONCERN 9 (authoritative eligibility)**: confirm the factory's
+>    `_destroy` checks `candidate.state not in VASTAI_ELIGIBLE_STATES`
+>    and returns `INELIGIBLE_STATE`.
+> 10. **CONCERN 10 (InstanceCandidate fields)**: confirm
+>     `gpu_model`, `cost_per_hour`, `ownership_key` are added.
+> 11. **CONCERN 11 (CLI flag rename)**: confirm `--allowed-images`
+>     is preserved as canonical and `--owned-images` is an alias.
+> 12. **NIT 12 (provider assignment)**: confirm `provider=Provider.VASTAI`
+>     is hardcoded (not derived from canonical.docker_image).
+> 13. **NIT 13 (provider-mismatch diagnostic)**: confirm the error
+>     message includes the instance ID, actual provider, and
+>     expected provider.
+> 14. **NIT 14 (stale prose)**: confirm all references to
+>     `is_candidate`, "hostile classification", "verbidden", and
+>     "the core module has provider-specific imports" are removed.
 >
 > Additionally, identify any new BLOCKERs or CONCERNs introduced
-> by the second draft. Focus on:
-> - The `_repository(image_ref)` function: does it correctly
->   handle edge cases (empty string, sha256 digests, multi-tag
->   references)?
-> - The `OwnershipPolicy.__post_init__` freezing: is the
->   `object.__setattr__` pattern correct on a frozen dataclass?
-> - The `ProviderCleanupPolicy.destroy` provider-mismatch check:
->   is the error message operator-friendly?
-> - The `VastaiProviderConfig.from_env` constructor: does the
->   `docker_image or DEFAULT_IMAGE` guard correctly handle the
->   empty-string case?
-> - The migration step 5: does the `--allowed-images` rename to
->   `--owned-images` introduce a wire-format break that should be
->   deferred?
+> by the third draft. Focus on:
+> - The `CleanupResult` verdict/refusal mapping in
+>   `build_vastai_cleanup_policy._destroy`: is the translation
+>   table complete and correct?
+> - The `_destroy` catch-all exception path: does it return
+>   `verdict=UNKNOWN` or `refusal=...` consistently?
+> - The `ProviderCleanupPolicy.destroy` catch-all: same question.
+> - The VastaiRunner `allowed_images` deprecation: is the
+>   `DeprecationWarning` emitted with the correct stacklevel?
+> - The `OwnershipPolicy._normalised` caching: is the
+>   `object.__setattr__` pattern correct on a frozen dataclass
+>   for an internal-cache field?
+> - The `VastaiProviderConfig.__post_init__` ordering: are the
+>   `docker_image` non-empty check and the ownership-membership
+>   check in the right order?
+> - The `build_vastai_cleanup_policy` EXPLICITLY_DISABLED short-
+>   circuit: is the log message appropriate (warning vs. info)?
+> - The `_destroy` eligibility check: is `VASTAI_ELIGIBLE_STATES`
+>   complete (covers all stuck/loading/created states)?
+> - The `_repository` helper: does it handle port-only registries
+>   (`localhost:5000/myorg/app`) correctly?
 >
 > Return a labeled list of findings. Each finding is one of:
 > BLOCKER (must fix before merge), CONCERN (should fix, but not

--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -38,25 +38,27 @@ CLI fallback (CLI ownership verification + CLI destroy →
 `CLI_ATTEMPTED` verdict). The factory wraps `list_vastai_instances`
 so `EXPLICITLY_DISABLED` credentials short-circuit before enumeration.
 The orchestrator logs every non-`DESTROYED` outcome at a severity
-matching its operational impact (`LEAKED` = `ERROR`, `UNKNOWN` /
-`CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, refusals =
-`INFO`). The `VastaiRunner.destroy_instance` method delegates entirely
-to the v3 adapter (no v2 regression).
+matching its operational impact (`LEAKED` = `ERROR`, unexpected
+`NO_CREDENTIALS` = `WARNING`, `UNKNOWN` / `CLI_ATTEMPTED` /
+`CREDENTIALS_DISABLED` = `WARNING`, refusals = `INFO`). The
+`VastaiRunner.destroy_instance` method delegates entirely to the v3
+adapter (no v2 regression) and logs the typed `DestroyResult` for
+non-`DESTROYED` outcomes.
 
 Diff vs v3 once v3 is implemented:
 
-- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, non-empty `instance_id` invariant), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`, declared `_normalised` cache field)
+- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, non-empty `instance_id` invariant), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`, declared `_normalised` cache field). The `ProviderCleanupPolicy.destroy()` method validates the `destroy_fn` callback return type (cannot return `None` or a non-`CleanupResult`).
+- **+** `src/vastai_gpu_runner/providers/destroy.py` — `DestroyVerdict`, `DestroyRefusal`, `DestroyResult` (v3 verbatim — the canonical destroy types live here, not in the adapter).
+- **~** `src/vastai_gpu_runner/providers/destroy_adapters/vastai.py` — only `CredentialState`, `CredentialResolution`, `read_vastai_api_key()` (v3 env-first + fail-closed semantics), and the amended `destroy_vastai_instance()` signature (`ownership: OwnershipPolicy`, `credentials: CredentialResolution | None`). The destroy types are imported from `providers/destroy.py`, not redefined.
 - **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc.)
 - **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(*, ownership, credentials)` — provider-owned factory that takes the two canonical objects directly (no config wrapper)
-- **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`, validates `instance_id` non-empty
-- **~** `providers/destroy_adapters/vastai.py:destroy_vastai_instance` accepts `ownership: OwnershipPolicy` directly (replaces `allowed_images: frozenset[str]`); accepts `credentials: CredentialResolution | None` (defaults to `read_vastai_api_key()` for back-compat direct callers). The v3 implementation must adopt this signature.
-- **~** `providers/destroy_adapters/vastai.py:CredentialState` is `StrEnum` (matches v3 verbatim — the v4 third draft used plain `Enum`).
+- **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`, validates `instance_id` is a non-`None` non-empty string
 - **~** `VastaiRunner.__init__` accepts `ownership: OwnershipPolicy | None` and `credentials: CredentialResolution | None`; rejects simultaneous `ownership=` and deprecated `allowed_images=` with `ValueError`.
 - **~** `VastaiRunner.from_config(config)` preserves both `canonical.ownership` and `canonical.credentials`.
-- **~** `VastaiRunner.destroy_instance` delegates entirely to `destroy_vastai_instance(...)` — no v2-style inline ownership pre-check, no inline REST stop/delete/verify. Returns `bool` from the typed adapter result.
+- **~** `VastaiRunner.destroy_instance` delegates entirely to `destroy_vastai_instance(...)` — no v2-style inline ownership pre-check, no inline REST stop/delete/verify. Returns `bool` from the typed adapter result, logging the typed `DestroyResult` for non-`DESTROYED` outcomes.
 - **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required). The orchestrator calls `policy.list_instances()` and `policy.destroy(candidate)` — never branches on `Provider`, never imports provider modules.
 - **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and tracked-id exclusion stay on the orchestrator. Every other decision is delegated to `policy.destroy()`. The orchestrator logs every non-`DESTROYED` outcome at severity matching operational impact.
-- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new API. The `--allowed-images` flag is the canonical primary; `--owned-images` is an alias.
+- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new API. The `--allowed-images` flag is the canonical primary; `--owned-images` is an alias. Empty `--allowed-images ""` is **fail-closed** (empty set rejects every image), not opt-out.
 - **—** `orchestrator.py:sweep_zombie_instances` (v3 deletion) — reaffirmed. The v4 implementation removes the last direct caller.
 - **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) — reaffirmed.
 - **—** `providers/vastai.py:_image_is_allowed` (raw set check) — replaced by `OwnershipPolicy.matches()`.
@@ -84,41 +86,51 @@ in `VastaiProviderConfig` (because the runner also needs
 `docker_image`, `setup_commands`, etc.); the cleanup-policy factory
 takes them directly.
 
-## What changes vs the v4 first + second + third drafts (5th + 6th + 7th pass reviews)
+## What changes vs the v4 first + second + third + fourth drafts
 
 The first draft was rejected with 5 BLOCKERs and 7 CONCERNs. The
 second draft was rejected with 7 BLOCKERs, 2 CONCERNs, and 3 NITs.
 The third draft was rejected with 6 BLOCKERs, 4 CONCERNs, and 2 NITs.
-This fourth draft addresses every finding.
+The fourth draft was rejected with 5 BLOCKERs and 3 CONCERNs. This
+fifth draft addresses every finding.
 
-### Applied from the 7th-pass review (this pass)
+### Applied from the 8th-pass review (this pass)
 
-- **ABSENT-credential CLI fallback implemented** in the factory. The factory intercepts `DestroyRefusal.NO_CREDENTIALS` and runs the CLI fallback path: `verify_instance_ownership` (CLI auth context) → if not owned return `OWNERSHIP`, else `vastai_cmd(["destroy", "instance", ...])` → `CLI_ATTEMPTED` (destruction unconfirmed) on command success or `UNKNOWN` on command failure. The canonical ABSENT resolution is passed to the REST adapter (not `None`). (BLOCKER 1)
-- **v3 `DestroyResult` translation corrected.** v3 `DestroyVerdict` has exactly `DESTROYED | LEAKED | UNKNOWN` (no `CLI_ATTEMPTED` — that's only in v4 `CleanupVerdict`). v3 `DestroyResult` has `attempts`, `stop_error`, `last_status_code`, `verify_error` — no generic `error` field. Diagnostic text is built from the structured fields via a `_describe(result)` helper. (BLOCKER 2)
-- **`VastaiRunner.destroy_instance` delegates to v3 adapter.** No v2-style inline ownership pre-check, no inline REST stop/delete/verify. The runner adds `credentials` to its constructor, `from_config` preserves the canonical `CredentialResolution`, and `destroy_instance` is a single adapter call. Simultaneous `ownership=` and `allowed_images=` raises `ValueError`. (BLOCKER 3)
-- **`never raises` catch path hardened.** The catch returns `error=f"{type(exc).__name__}: {exc}"` so `error` is always non-empty even for `RuntimeError()` with no message. The `CleanupResult.__post_init__` invariant is preserved. (BLOCKER 4)
-- **`build_vastai_cleanup_policy` takes `ownership` + `credentials` directly.** No `VastaiProviderConfig` wrapper — the deployment-image invariant in `VastaiProviderConfig.__post_init__` does not apply to listing/cleanup-only commands. The batch command extracts `ownership` and `credentials` from `VastaiProviderConfig`; the cleanup command constructs them directly from CLI args. (BLOCKER 5)
-- **`instance_id` non-empty validated at two boundaries.** `list_vastai_instances` skips records with empty `instance_id`; `InstanceCandidate.__post_init__` raises `ValueError` for empty or whitespace-only IDs. (BLOCKER 6)
-- **`_normalised` declared as a dataclass field** with `field(init=False, repr=False, compare=False)`. The `object.__setattr__` pattern in `__post_init__` is retained. (CONCERN 7)
-- **`CredentialState` uses `StrEnum`** matching v3 verbatim. (CONCERN 8)
-- **`VASTAI_TERMINAL_STATES` (negative list)** replaces the previous positive allowlist. Only `destroyed` is skipped; new Vast.ai states are processed. (CONCERN 9)
-- **Logging severity by outcome.** `LEAKED` = `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, refusals = `INFO`. Each log line includes the instance ID. (CONCERN 10)
-- **`--allowed-images` is the canonical CLI flag** (declared first in `typer.Option`); `--owned-images` is the alias. The Python parameter is `allowed_images`. (NIT 11)
-- **Historical `is_candidate` reference removed** from the prose (the historical change summary no longer mentions it; the active flow is what matters). (NIT 12)
+- **Module ownership corrected.** `DestroyVerdict` / `DestroyRefusal` / `DestroyResult` are now defined in `providers/destroy.py` (v3 verbatim) and *imported* by the adapter and the runner — not redefined in the adapter. The runner's `providers/vastai.py` imports them from `providers.destroy`, not from `providers.destroy_adapters.vastai`. `vastai_cmd` and `verify_instance_ownership` are local to `providers/vastai.py` (no import). (BLOCKER 1)
+- **`read_vastai_api_key` rewritten per v3 env-first contract.** Inspects `VASTAI_API_KEY` env var first (present-but-empty → `EXPLICITLY_DISABLED`, present-and-non-empty → `AVAILABLE`); falls back to credential files; blank/unreadable files log a warning and continue as `ABSENT` (NOT disabled); catches `OSError`. (BLOCKER 2)
+- **`DestroyResult` types referenced from v3 verbatim.** The adapter block no longer defines `DestroyResult` / `DestroyVerdict` / `DestroyRefusal`. The v4 factory imports them from `providers.destroy`. Optional diagnostic fields with `None` defaults; invariants enforced in `__post_init__`: exactly one of verdict/refusal, no protocol context on refusals, ≥1 attempt on verdict outcomes. `_describe()` handles `None` fields gracefully. (BLOCKER 3)
+- **Empty `--allowed-images` is fail-closed.** The cleanup CLI distinguishes `None` (flag omitted → opt-out `OwnershipPolicy()`) from `""` (explicit empty → empty set `OwnershipPolicy(owned_images=frozenset())` → reject everything). Whitespace-only entries in comma-separated input are stripped. (BLOCKER 4)
+- **Null provider ID rejected.** `list_vastai_instances` validates `inst` is a dict, then explicitly checks `inst.get("id") is None` (catches `id: null` JSON which `str(None)` would convert to the literal `"None"`). Records with null/empty/whitespace IDs are skipped with a warning. (BLOCKER 5)
+- **`destroy_fn` return type validated.** `ProviderCleanupPolicy.destroy()` checks the callback's return is a `CleanupResult` instance; if not, returns `CleanupResult(verdict=UNKNOWN, error="destroy_fn returned invalid result type ...")` so the orchestrator never sees a non-`CleanupResult`. (CONCERN 6)
+- **Unexpected `NO_CREDENTIALS` escalated to WARNING.** If the factory's CLI fallback path is bypassed and `NO_CREDENTIALS` reaches the orchestrator, that means the orphan was not cleaned up. Bumped from INFO to WARNING. (CONCERN 7)
+- **`VastaiRunner.destroy_instance` logs the typed result.** The runner keeps the single adapter call but logs `DestroyResult` verdict/refusal + diagnostic context before returning `False`. No v2 inline destroy logic reintroduced. (CONCERN 8)
+
+### Applied from the 7th-pass review (fourth pass)
+
+- ABSENT-credential CLI fallback (factory intercepts `NO_CREDENTIALS`).
+- Correct v3 `DestroyResult` translation (no `result.error`, use `_describe()`).
+- `VastaiRunner.destroy_instance` delegation (superseded by CONCERN 8 above).
+- Non-empty catch error (`f"{type(exc).__name__}: {exc}"`).
+- `build_vastai_cleanup_policy(*, ownership, credentials)` direct args.
+- `instance_id` non-empty validation (superseded by BLOCKER 5 above).
+- `_normalised` declared as `field(init=False, repr=False, compare=False)`.
+- `CredentialState(StrEnum)`.
+- `VASTAI_TERMINAL_STATES` (negative allowlist).
+- Severity logging (LEAKED = ERROR, etc.).
+- `--allowed-images` canonical (superseded by BLOCKER 4 above).
+- Historical `is_candidate` reference removed.
 
 ### Applied from the 6th-pass review (third pass)
 
-- `_repository(image_ref)` strips digest, strips only the final tag separator (after the last `/`), preserves registry and port, rejects malformed references.
+- `_repository(image_ref)` strips digest, strips only the final tag separator, preserves registry and port.
 - Runner and adapter consume `OwnershipPolicy.matches()` directly.
-- v3 type names used exactly (`CredentialState`, `CredentialResolution`).
+- v3 type names used exactly.
 - `EXPLICITLY_DISABLED` short-circuits before enumeration.
-- CLI fallback + `DestroyResult` translation (superseded by 7th-pass BLOCKER 1 above).
 - `docker_image` non-empty + pre-stripped invariant.
 - Undefined names fixed (logger import, OwnershipPolicy imports).
 - `CleanupResult` invariants tightened.
-- Authoritative eligibility implemented (now superseded by 7th-pass CONCERN 9 negative-list).
+- Authoritative eligibility implemented (later replaced by negative terminal-states list).
 - `InstanceCandidate` enriched with `gpu_model`, `cost_per_hour`, `ownership_key`.
-- CLI flag kept as `--allowed-images` canonical.
 
 ### Applied from the 5th-pass review (second pass)
 
@@ -126,26 +138,32 @@ This fourth draft addresses every finding.
 - `list_instances_fn` + `list_instances()` method on the policy.
 - `destroy()` is authoritative.
 - Hostile check removed.
-- v3 `CredentialResolution` types used.
 - `OwnershipPolicy.matches()` introduced.
 - CLI uses `dataclasses.replace`.
 - Provider factories moved to `providers/vastai.py`.
-- State filter removed (now superseded by 7th-pass CONCERN 9 negative-list).
 - `CleanupResult` invariants added.
 - `from_runpod_config` removed.
 - Migration order revised.
-
-### Applied from the 5th-pass review (first draft)
-
-- The first draft had BLOCKERs 1-5 and CONCERNs 1-7; all addressed in subsequent passes.
 
 ## Module taxonomy
 
 The v4 doc adds one new module at the layer above the v3 destroy
 protocol. The `CloudRunner` ABC, `BatchOrchestrator`, `unit_lifecycle`,
 `providers/destroy`, and `providers/destroy_adapters/vastai` are
-unchanged in shape (v3 implementation is still a prerequisite, with
-the v3 adapter signature amended per BLOCKER 2 above).
+unchanged in shape (v3 implementation is still a prerequisite).
+
+### Module ownership (clarified)
+
+| Module | Owns |
+|---|---|
+| `providers/destroy.py` (v3) | `DestroyVerdict`, `DestroyRefusal`, `DestroyResult` (canonical destroy types) |
+| `providers/destroy_adapters/vastai.py` (v3 + v4) | `CredentialState`, `CredentialResolution`, `read_vastai_api_key()` (env-first), `destroy_vastai_instance()` (amended signature: `ownership: OwnershipPolicy`, `credentials: CredentialResolution \| None`) |
+| `providers/vastai.py` (v4) | `VastaiProviderConfig`, `VastaiRunner` (delegates destroy to v3 adapter), `vastai_cmd`, `verify_instance_ownership`, `list_vastai_instances()`, `build_vastai_cleanup_policy()`, `VASTAI_TERMINAL_STATES` |
+| `cleanup_policy.py` (v4) | `OwnershipPolicy`, `InstanceCandidate`, `CleanupVerdict`, `CleanupRefusal`, `CleanupResult`, `ProviderCleanupPolicy` |
+
+The core `cleanup_policy.py` module imports nothing from `providers/`.
+The `providers/vastai.py` module imports from both `providers/destroy`
+(types) and `providers/destroy_adapters/vastai` (the adapter).
 
 ### New: `cleanup_policy` — owns the DTOs + the generic policy class
 
@@ -154,11 +172,6 @@ Owns: `InstanceCandidate` (frozen DTO), `CleanupVerdict` enum,
 (frozen, shared ownership semantics), `ProviderCleanupPolicy`
 (frozen, `kw_only`, provider-agnostic, holds the `list_instances_fn`
 and `destroy_fn` callbacks).
-
-Does **not** own: provider-specific adapters (live in `providers/*`),
-REST URLs, API key paths, the destroy protocol loop (lives in
-`providers/destroy`), the enumeration logic (per provider). The
-core module imports nothing from `providers/`.
 
 ### New: `providers/vastai.py:build_vastai_cleanup_policy` — Vast.ai factory
 
@@ -200,12 +213,15 @@ RunPod adapter (roadmap item 2).
 ├─────────────────────────────────────────────────┤
 │  unit_lifecycle (unit_lifecycle.py)             │  v3: decision tree, no side effects
 ├─────────────────────────────────────────────────┤
-│  providers/destroy (providers/destroy.py)       │  v3: belt-and-suspenders protocol
+│  providers/destroy (providers/destroy.py)       │  v3: canonical DestroyResult types
+│    └── DestroyVerdict | DestroyRefusal |        │
+│        DestroyResult                            │
 ├─────────────────────────────────────────────────┤
-│  providers/destroy_adapters/vastai.py           │  v3: Vast.ai REST callbacks + policy
-│    └── destroy_vastai_instance(ownership=       │
-│        OwnershipPolicy, credentials=            │
-│        CredentialResolution | None)             │
+│  providers/destroy_adapters/vastai.py           │  v3 + v4: Vast.ai adapter
+│    └── CredentialState | CredentialResolution | │
+│        read_vastai_api_key (env-first) |         │
+│        destroy_vastai_instance(ownership=,      │
+│        credentials=)                            │
 ├─────────────────────────────────────────────────┤
 │  CloudRunner (runner.py) ── Lane A ABC          │  Provider-agnostic lifecycle
 ├──────────────┬──────────────┬───────────────────┤
@@ -387,7 +403,9 @@ class InstanceCandidate:
     expose; providers that do not have a field (e.g. RunPod has
     no ``image_uuid``) leave it empty.
 
-    Invariant: ``instance_id`` must be non-empty and pre-stripped.
+    Invariant: ``instance_id`` must be non-empty and pre-stripped
+    (an explicit JSON ``null`` is the caller's responsibility to
+    filter before constructing the candidate).
     """
 
     provider: "Provider"
@@ -486,9 +504,17 @@ class ProviderCleanupPolicy:
         on every call, then delegates to ``destroy_fn`` which
         applies eligibility / ownership / credential checks.
 
-        Never raises. The error string in the catch path is
-        always non-empty (uses ``type(exc).__name__`` as a
-        minimum) so the ``CleanupResult`` invariant is preserved.
+        Never raises. Two safety guarantees:
+
+        1. The catch-all uses ``f"{type(exc).__name__}: {exc}"``
+           so the error string is always non-empty (preserves
+           the ``CleanupResult`` invariant even for
+           ``raise RuntimeError()`` with no message).
+        2. The ``destroy_fn`` callback's return value is type-
+           checked: if the callback returns ``None`` or any non-
+           ``CleanupResult``, the policy substitutes a
+           ``CleanupResult(verdict=UNKNOWN, error=...)`` so the
+           orchestrator never sees an invalid result.
         """
         if candidate.provider != self.provider:
             return CleanupResult(
@@ -500,7 +526,7 @@ class ProviderCleanupPolicy:
                 ),
             )
         try:
-            return self.destroy_fn(candidate)
+            result = self.destroy_fn(candidate)
         except Exception as exc:
             logger.warning(
                 "Cleanup: destroy_fn raised for %s: %s",
@@ -511,12 +537,106 @@ class ProviderCleanupPolicy:
                 verdict=CleanupVerdict.UNKNOWN,
                 error=f"{type(exc).__name__}: {exc}",
             )
+        if not isinstance(result, CleanupResult):
+            logger.warning(
+                "Cleanup: destroy_fn for %s returned invalid result "
+                "type %s — substituting UNKNOWN",
+                candidate.instance_id,
+                type(result).__name__,
+            )
+            return CleanupResult(
+                verdict=CleanupVerdict.UNKNOWN,
+                error=(
+                    f"destroy_fn returned invalid result type "
+                    f"{type(result).__name__}"
+                ),
+            )
+        return result
+```
+
+## `providers/destroy.py` — v3 canonical destroy types (NEW)
+
+The v3 design places the canonical destroy types here. The v4 design
+uses them unchanged.
+
+```python
+# src/vastai_gpu_runner/providers/destroy.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Optional
+
+
+class DestroyVerdict(StrEnum):
+    """Outcome verdicts returned by the v3 belt-and-suspenders protocol.
+
+    Three values. ``CLI_ATTEMPTED`` is NOT a v3 verdict — it is a v4
+    ``CleanupVerdict`` produced by the factory's CLI fallback path.
+    """
+    DESTROYED = "destroyed"
+    LEAKED = "leaked"
+    UNKNOWN = "unknown"
+
+
+class DestroyRefusal(StrEnum):
+    """Pre-protocol refusal reasons returned by ``destroy_vastai_instance``."""
+    OWNERSHIP = "ownership"
+    NO_CREDENTIALS = "no_credentials"
+    CREDENTIALS_DISABLED = "credentials_disabled"
+
+
+@dataclass(frozen=True)
+class DestroyResult:
+    """Outcome of the v3 belt-and-suspenders destroy protocol.
+
+    Exactly one of ``verdict`` (DestroyVerdict) or ``refusal``
+    (DestroyRefusal) is set — never both. Optional diagnostic
+    fields carry the per-step status and error context. No
+    generic ``error`` field exists — refusals use the structured
+    refusal reason, verdicts use the per-step diagnostic fields.
+
+    Invariants (enforced in ``__post_init__``):
+        - Exactly one of ``verdict`` / ``refusal`` is set.
+        - Refusals carry no protocol context (the diagnostic
+          fields are at their defaults).
+        - Verdict outcomes require at least one attempt.
+    """
+    verdict: Optional[DestroyVerdict] = None
+    refusal: Optional[DestroyRefusal] = None
+    attempts: Optional[int] = None
+    last_status_code: Optional[int] = None
+    stop_error: Optional[str] = None
+    verify_error: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if (self.verdict is None) == (self.refusal is None):
+            raise ValueError(
+                "DestroyResult: exactly one of verdict or refusal must be set"
+            )
+        if self.refusal is not None:
+            if (
+                self.attempts is not None
+                or self.last_status_code is not None
+                or self.stop_error is not None
+                or self.verify_error is not None
+            ):
+                raise ValueError(
+                    "DestroyResult: refusal must not carry protocol context"
+                )
+        else:
+            # verdict is set; require at least one attempt.
+            if self.attempts is None or self.attempts < 1:
+                raise ValueError(
+                    "DestroyResult: verdict outcomes require attempts >= 1"
+                )
 ```
 
 ## `providers/destroy_adapters/vastai.py` — v3 + v4 additions
 
-The v3 design's `CredentialState` + `CredentialResolution` types
-plus the amended `destroy_vastai_instance` signature.
+The credential types + the env-first resolver + the amended
+`destroy_vastai_instance` signature. The adapter imports the
+destroy types from `providers/destroy.py` (not redefined here).
 
 ```python
 # src/vastai_gpu_runner/providers/destroy_adapters/vastai.py
@@ -532,17 +652,22 @@ from pathlib import Path
 from typing import Optional
 
 from vastai_gpu_runner.cleanup_policy import OwnershipPolicy
+from vastai_gpu_runner.providers.destroy import (
+    DestroyRefusal,
+    DestroyResult,
+    DestroyVerdict,
+)
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Credential types (v3 shape — verbatim)
+# Credential types (v3 shape)
 # ---------------------------------------------------------------------------
 
 
 class CredentialState(StrEnum):
-    """Three-state credential resolution."""
+    """Three-state credential resolution (v3 verbatim)."""
     AVAILABLE = "available"
     ABSENT = "absent"
     EXPLICITLY_DISABLED = "explicitly_disabled"
@@ -550,9 +675,9 @@ class CredentialState(StrEnum):
 
 @dataclass(frozen=True)
 class CredentialResolution:
-    """Output of read_vastai_api_key(). EMPTY unless state is AVAILABLE.
+    """Output of ``read_vastai_api_key``.
 
-    Invariants (enforced in __post_init__):
+    Invariants (enforced in ``__post_init__``):
         - AVAILABLE requires non-empty, pre-stripped key.
         - ABSENT and EXPLICITLY_DISABLED require empty key.
     """
@@ -573,79 +698,65 @@ class CredentialResolution:
 
 
 # ---------------------------------------------------------------------------
-# read_vastai_api_key
+# read_vastai_api_key — v3 env-first, fail-closed
 # ---------------------------------------------------------------------------
 
 
 def read_vastai_api_key() -> CredentialResolution:
-    """Read the Vast.ai API key from the standard file paths.
+    """Read the Vast.ai API key — env-first, fail-closed.
 
-    Returns a frozen CredentialResolution. The resolution distinguishes
-    three states:
-        - EXPLICITLY_DISABLED: the key file exists but is empty
-          (the user has explicitly disabled credentials).
-        - ABSENT: no key file is present.
-        - AVAILABLE: a non-empty key was found.
+    Resolution order:
+        1. Inspect ``VASTAI_API_KEY`` env var.
+        2. Present but empty/whitespace → ``EXPLICITLY_DISABLED``
+           (the user has explicitly disabled credentials).
+        3. Present and non-empty → ``AVAILABLE`` with stripped key.
+        4. Then inspect credential files
+           (``~/.config/vastai/vast_api_key``, ``~/.vast_api_key``).
+        5. Blank file → warning, treat as ``ABSENT`` (CLI fallback
+           is permitted).
+        6. Unreadable file (``OSError``) → warning, treat as ``ABSENT``.
+        7. No file present → ``ABSENT``.
+
+    Invariant: ``EXPLICITLY_DISABLED`` is reserved for the case
+    where the user has explicitly opted out via the env var.
+    A blank or unreadable file does NOT mean disabled — that
+    would silently block the controlled CLI fallback.
     """
+    env_key = os.environ.get("VASTAI_API_KEY")
+    if env_key is not None:
+        stripped = env_key.strip()
+        if not stripped:
+            return CredentialResolution(state=CredentialState.EXPLICITLY_DISABLED)
+        return CredentialResolution(state=CredentialState.AVAILABLE, key=stripped)
+
     for kp in (
         Path("~/.config/vastai/vast_api_key").expanduser(),
         Path("~/.vast_api_key").expanduser(),
     ):
-        if kp.exists():
-            raw = kp.read_text()
-            stripped = raw.strip()
-            if not stripped:
-                return CredentialResolution(
-                    state=CredentialState.EXPLICITLY_DISABLED
+        try:
+            if kp.exists():
+                raw = kp.read_text()
+                stripped = raw.strip()
+                if stripped:
+                    return CredentialResolution(
+                        state=CredentialState.AVAILABLE, key=stripped
+                    )
+                # Blank file: warn, continue as ABSENT.
+                logger.warning(
+                    "Credential file %s is empty; treating as ABSENT "
+                    "(CLI fallback will be attempted)",
+                    kp,
                 )
-            return CredentialResolution(
-                state=CredentialState.AVAILABLE, key=stripped
+        except OSError as exc:
+            logger.warning(
+                "Could not read credential file %s: %s; "
+                "treating as ABSENT",
+                kp,
+                exc,
             )
+            continue
+
     return CredentialResolution(state=CredentialState.ABSENT)
-
-
-# ---------------------------------------------------------------------------
-# DestroyResult shape (v3)
-# ---------------------------------------------------------------------------
-
-
-class DestroyVerdict(StrEnum):
-    """Outcome verdicts returned by the v3 belt-and-suspenders protocol.
-
-    Three values. CLI_ATTEMPTED is NOT a v3 verdict — it is a v4
-    CleanupVerdict produced by the factory's CLI fallback.
-    """
-    DESTROYED = "destroyed"
-    LEAKED = "leaked"
-    UNKNOWN = "unknown"
-
-
-class DestroyRefusal(StrEnum):
-    """Pre-protocol refusal reasons returned by destroy_vastai_instance."""
-    OWNERSHIP = "ownership"
-    NO_CREDENTIALS = "no_credentials"
-    CREDENTIALS_DISABLED = "credentials_disabled"
-
-
-@dataclass(frozen=True)
-class DestroyResult:
-    """Outcome of the v3 belt-and-suspenders destroy protocol.
-
-    Exactly one of ``verdict`` (DestroyVerdict) or ``refusal``
-    (DestroyRefusal) is set. The structured fields carry the
-    diagnostic context for the verdict path; the refusal path
-    uses stable message synthesis in the factory.
-
-    The fields below are the v3 contract. No generic ``error``
-    field exists — refusals carry structured refusal reasons,
-    verdicts carry per-step status and error strings.
-    """
-    verdict: Optional[DestroyVerdict] = None
-    refusal: Optional[DestroyRefusal] = None
-    attempts: int = 0
-    last_status_code: int = 0
-    stop_error: str = ""
-    verify_error: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -665,25 +776,26 @@ def destroy_vastai_instance(
         instance_id: Vast.ai instance ID.
         ownership: Shared ownership policy. The runner and the
             cleanup adapter both pass the same instance.
-        credentials: Pre-resolved credential state. When None
+        credentials: Pre-resolved credential state. When ``None``
             (the default), falls back to ``read_vastai_api_key()``
             — preserves the v3 back-compat path for direct callers.
 
     Returns:
         ``DestroyResult`` with either ``verdict`` or ``refusal``
-        (never both).
+        (never both). CLI fallback is performed by the v4 factory,
+        not by this adapter — the adapter's credential handling
+        is simple and stateless.
 
     Behaviour by credential state:
-        - EXPLICITLY_DISABLED → refusal CREDENTIALS_DISABLED
-        - ABSENT → refusal NO_CREDENTIALS (the v4 factory
-          intercepts this and runs the CLI fallback)
+        - EXPLICITLY_DISABLED → ``refusal=CREDENTIALS_DISABLED``
+          (no provider calls).
+        - ABSENT → ``refusal=NO_CREDENTIALS`` (the v4 factory
+          intercepts this and runs the CLI fallback).
         - AVAILABLE → REST path: ownership check via API, then
           belt-and-suspenders (stop → DELETE×retry → verify →
-          re-destroy). Returns DESTROYED / LEAKED / UNKNOWN.
-
-    CLI fallback is performed by the v4 factory, not by this
-    adapter (the v3 contract keeps the adapter's credential
-    handling simple and stateless).
+          re-destroy). Returns ``verdict=DESTROYED`` on confirmed
+          destruction, ``LEAKED`` on resurrection, ``UNKNOWN``
+          on indeterminate outcome.
     """
     resolution = credentials or read_vastai_api_key()
     if resolution.state == CredentialState.EXPLICITLY_DISABLED:
@@ -692,13 +804,18 @@ def destroy_vastai_instance(
         return DestroyResult(refusal=DestroyRefusal.NO_CREDENTIALS)
     # AVAILABLE: REST path.
     # ... ownership check via API, belt-and-suspenders, return
-    # DestroyResult with verdict=DESTROYED/LEAKED/UNKNOWN ...
+    # DestroyResult with verdict=DESTROYED/LEAKED/UNKNOWN and the
+    # structured diagnostic fields populated ...
 ```
 
 ## `providers/vastai.py` — full module updates
 
 The `VastaiProviderConfig`, `VastaiRunner`, `list_vastai_instances`,
-and `build_vastai_cleanup_policy` shapes.
+and `build_vastai_cleanup_policy` shapes. The destroy types are
+imported from `providers/destroy.py`; the credential types and the
+adapter are imported from `providers/destroy_adapters/vastai.py`.
+The local `vastai_cmd` and `verify_instance_ownership` helpers are
+not imported from elsewhere.
 
 ```python
 # src/vastai_gpu_runner/providers/vastai.py
@@ -721,16 +838,16 @@ from vastai_gpu_runner.cleanup_policy import (
     OwnershipPolicy,
     ProviderCleanupPolicy,
 )
-from vastai_gpu_runner.providers.destroy_adapters.vastai import (
-    CredentialResolution,
-    CredentialState,
+from vastai_gpu_runner.providers.destroy import (
     DestroyRefusal,
     DestroyResult,
     DestroyVerdict,
+)
+from vastai_gpu_runner.providers.destroy_adapters.vastai import (
+    CredentialResolution,
+    CredentialState,
     destroy_vastai_instance,
     read_vastai_api_key,
-    vastai_cmd,
-    verify_instance_ownership,
 )
 from vastai_gpu_runner.runner import CloudRunner
 from vastai_gpu_runner.ssh import scp_download, scp_upload, ssh_cmd
@@ -751,6 +868,71 @@ MIN_GPU_VRAM_MIB = 20_000
 # allowlist (terminal-skip) is conservative: new Vast.ai states that
 # are not yet terminal are processed, not silently skipped.
 VASTAI_TERMINAL_STATES: frozenset[str] = frozenset({"destroyed"})
+
+
+# ---------------------------------------------------------------------------
+# vastai_cmd + verify_instance_ownership — local provider helpers
+# ---------------------------------------------------------------------------
+
+
+def vastai_cmd(args: list[str], *, timeout: int = 30) -> str:
+    """Run a vastai CLI command (local to providers/vastai.py).
+
+    Raises ``RuntimeError`` on non-zero return, timeout, or missing CLI.
+    """
+    cmd = ["vastai", *args]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        if result.returncode != 0:
+            msg = f"vastai {' '.join(args)} failed: {result.stderr.strip()}"
+            raise RuntimeError(msg)
+        return result.stdout.strip()
+    except FileNotFoundError as exc:
+        msg = "vastai CLI not installed. Install with: pip install vastai"
+        raise RuntimeError(msg) from exc
+    except subprocess.TimeoutExpired as exc:
+        msg = f"vastai {' '.join(args)} timed out after {timeout}s"
+        raise RuntimeError(msg) from exc
+
+
+def verify_instance_ownership(
+    instance_id: str,
+    *,
+    ownership: OwnershipPolicy,
+) -> bool:
+    """Check that a Vast.ai instance belongs to the caller before destruction.
+
+    Uses ``ownership.matches(image_uuid)`` for the ownership check.
+    This is the CLI-auth verification used by the v4 factory's
+    CLI fallback path (separate auth context from the REST path).
+    """
+    if ownership.owned_images is None:
+        return True
+    try:
+        raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
+        instances = json.loads(raw)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Cannot verify ownership of instance %s (API error: %s) — refusing to destroy",
+            instance_id,
+            exc,
+        )
+        return False
+    for inst in instances:
+        if str(inst.get("id")) == str(instance_id):
+            image = str(inst.get("image_uuid", ""))
+            if ownership.matches(image):
+                return True
+            logger.error(
+                "BLOCKED: instance %s belongs to another project (image=%s). Will NOT destroy.",
+                instance_id,
+                image,
+            )
+            return False
+    logger.info("Instance %s not found in account (already destroyed?)", instance_id)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -836,16 +1018,17 @@ class VastaiRunner(CloudRunner):
         ownership: Ownership policy. The runner and the cleanup
             adapter both call ``ownership.matches(image_ref)``.
         credentials: Pre-resolved credential state. When None,
-            the runner uses ``read_vastai_api_key()`` (the v3
-            back-compat path).
+            the runner passes ``None`` to the adapter, which
+            calls ``read_vastai_api_key()`` (the v3 back-compat path).
         docker_image: Docker image to use for new instances.
         min_gpu_vram_mib: Minimum GPU VRAM required (default 20 GB).
         setup_commands: Optional pre-instance setup commands.
 
     Note: ``allowed_images`` is a deprecated back-compat alias
-    that builds an ``OwnershipPolicy`` from the given set. Simultaneous
-    ``ownership=`` and ``allowed_images=`` raises ``ValueError`` —
-    silently ignoring one destruction-safety configuration is unsafe.
+    that builds an ``OwnershipPolicy`` from the given set.
+    Simultaneous ``ownership=`` and ``allowed_images=`` raises
+    ``ValueError`` — silently ignoring one destruction-safety
+    configuration is unsafe.
     """
 
     def __init__(
@@ -922,7 +1105,9 @@ class VastaiRunner(CloudRunner):
         a single adapter call with no inline destroy logic.
 
         Returns True iff the adapter reports ``verdict=DESTROYED``.
-        LEAKED, UNKNOWN, and all refusals return False.
+        For every other outcome, the typed ``DestroyResult`` is
+        logged before returning False so operators can diagnose
+        why the destroy failed (LEAKED, UNKNOWN, or any refusal).
         """
         result = destroy_vastai_instance(
             instance.instance_id,
@@ -932,63 +1117,80 @@ class VastaiRunner(CloudRunner):
         if result.verdict == DestroyVerdict.DESTROYED:
             instance.status = InstanceStatus.DESTROYED
             return True
-        return False
-
-
-# ---------------------------------------------------------------------------
-# verify_instance_ownership — uses OwnershipPolicy.matches()
-# ---------------------------------------------------------------------------
-
-
-def verify_instance_ownership(
-    instance_id: str,
-    *,
-    ownership: OwnershipPolicy,
-) -> bool:
-    """Check that a Vast.ai instance belongs to the caller before destruction.
-
-    Uses ``ownership.matches(image_uuid)`` for the ownership check.
-    This is the CLI-auth verification used by the v4 factory's
-    CLI fallback path (separate auth context from the REST path).
-    """
-    if ownership.owned_images is None:
-        return True
-    try:
-        raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
-        instances = json.loads(raw)
-    except (RuntimeError, json.JSONDecodeError) as exc:
-        logger.warning(
-            "Cannot verify ownership of instance %s (API error: %s) — refusing to destroy",
-            instance_id,
-            exc,
-        )
-        return False
-    for inst in instances:
-        if str(inst.get("id")) == str(instance_id):
-            image = str(inst.get("image_uuid", ""))
-            if ownership.matches(image):
-                return True
+        # Non-DESTROYED: log the typed result before collapsing to False.
+        if result.verdict == DestroyVerdict.LEAKED:
             logger.error(
-                "BLOCKED: instance %s belongs to another project (image=%s). Will NOT destroy.",
-                instance_id,
-                image,
+                "Destroy %s LEAKED — manual review required: %s",
+                instance.instance_id,
+                _describe(result),
             )
-            return False
-    logger.info("Instance %s not found in account (already destroyed?)", instance_id)
-    return True
+        elif result.verdict == DestroyVerdict.UNKNOWN:
+            logger.warning(
+                "Destroy %s outcome=UNKNOWN: %s",
+                instance.instance_id,
+                _describe(result),
+            )
+        elif result.refusal == DestroyRefusal.OWNERSHIP:
+            logger.error(
+                "Destroy %s refused (ownership check rejected): %s",
+                instance.instance_id,
+                _describe(result),
+            )
+        elif result.refusal == DestroyRefusal.NO_CREDENTIALS:
+            logger.error(
+                "Destroy %s refused (no credentials): %s",
+                instance.instance_id,
+                _describe(result),
+            )
+        elif result.refusal == DestroyRefusal.CREDENTIALS_DISABLED:
+            logger.error(
+                "Destroy %s refused (credentials disabled): %s",
+                instance.instance_id,
+                _describe(result),
+            )
+        else:
+            logger.error(
+                "Destroy %s returned unrecognised result: %s",
+                instance.instance_id,
+                _describe(result),
+            )
+        return False
+
+
+def _describe(result: DestroyResult) -> str:
+    """Build diagnostic text from v3 DestroyResult structured fields.
+
+    Handles ``None`` fields gracefully (v3 uses optional diagnostics).
+    Always produces non-empty output.
+    """
+    return (
+        f"attempts={result.attempts}, "
+        f"last_status={result.last_status_code}, "
+        f"verify_error={result.verify_error!r}, "
+        f"stop_error={result.stop_error!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
-# list_vastai_instances — validates instance_id non-empty
+# list_vastai_instances — validates instance_id type + content
 # ---------------------------------------------------------------------------
 
 
 def list_vastai_instances() -> list[InstanceCandidate]:
     """Read-only enumeration of Vast.ai instances on this account.
 
-    Returns ``InstanceCandidate`` records. Records with missing
-    or empty ``instance_id`` are skipped (logged). A failure to
-    enumerate returns an empty list.
+    Returns ``InstanceCandidate`` records. Records with missing,
+    null, or empty ``instance_id`` are skipped (logged). A failure
+    to enumerate returns an empty list.
+
+    Validation guards:
+        - ``inst`` must be a dict (otherwise skip).
+        - ``inst.get("id")`` must not be ``None`` (JSON null is not
+          a valid Vast.ai instance ID; ``str(None)`` would produce
+          the literal string ``"None"`` which passes falsy checks).
+        - ``instance_id`` must be non-empty after strip.
+        - Other malformed fields are caught by the per-record
+          ``try`` block.
 
     NB: this helper does NOT enforce the EXPLICITLY_DISABLED
     short-circuit. The factory wraps this function with the
@@ -1002,11 +1204,27 @@ def list_vastai_instances() -> list[InstanceCandidate]:
     except (RuntimeError, json.JSONDecodeError) as exc:
         logger.warning("list_vastai_instances: enumeration failed: %s", exc)
         return candidates
+    if not isinstance(instances, list):
+        logger.warning(
+            "list_vastai_instances: expected list, got %s — skipping enumeration",
+            type(instances).__name__,
+        )
+        return candidates
     for inst in instances:
-        instance_id = str(inst.get("id", "")).strip()
+        if not isinstance(inst, dict):
+            logger.warning("Skipping non-object instance record: %r", inst)
+            continue
+        raw_id = inst.get("id")
+        if raw_id is None:
+            logger.warning(
+                "Skipping instance with null ID: %r",
+                {k: inst.get(k) for k in ("label", "image_uuid", "actual_status")},
+            )
+            continue
+        instance_id = str(raw_id).strip()
         if not instance_id:
             logger.warning(
-                "Skipping instance with missing ID: %s",
+                "Skipping instance with empty ID: %r",
                 {k: inst.get(k) for k in ("label", "image_uuid", "actual_status")},
             )
             continue
@@ -1050,7 +1268,7 @@ def build_vastai_cleanup_policy(
 
     The wired ``list_instances_fn`` enforces the v3 contract:
     ``EXPLICITLY_DISABLED`` credentials return ``[]`` without
-    invoking CLI enumeration (no API key, no CLI fallback — fail-closed).
+    invoking CLI enumeration.
 
     The wired ``destroy_fn`` runs:
         1. Eligibility check (skip terminal states like ``destroyed``).
@@ -1059,8 +1277,7 @@ def build_vastai_cleanup_policy(
            fallback path: CLI ownership verification → CLI destroy →
            ``CLI_ATTEMPTED`` (destruction unconfirmed) or ``UNKNOWN``.
         4. Translate all three v3 verdicts and all three v3 refusals
-           into the v4 ``CleanupResult`` shape, with diagnostic text
-           built from the structured ``DestroyResult`` fields.
+           into the v4 ``CleanupResult`` shape.
     """
     provider = Provider.VASTAI
 
@@ -1076,15 +1293,6 @@ def build_vastai_cleanup_policy(
             )
             return []
         return list_vastai_instances()
-
-    def _describe(result: DestroyResult) -> str:
-        """Build diagnostic text from v3 DestroyResult structured fields."""
-        return (
-            f"attempts={result.attempts}, "
-            f"last_status={result.last_status_code}, "
-            f"verify_error={result.verify_error!r}, "
-            f"stop_error={result.stop_error!r}"
-        )
 
     def _cli_fallback(candidate: InstanceCandidate) -> CleanupResult:
         """CLI fallback path for ABSENT credentials.
@@ -1180,11 +1388,11 @@ def build_vastai_cleanup_policy(
         if result.verdict == DestroyVerdict.LEAKED:
             return CleanupResult(
                 verdict=CleanupVerdict.LEAKED,
-                error=_describe(result),
+                error=_describe_destroy_result(result),
             )
         return CleanupResult(
             verdict=CleanupVerdict.UNKNOWN,
-            error=_describe(result),
+            error=_describe_destroy_result(result),
         )
 
     return ProviderCleanupPolicy(
@@ -1193,19 +1401,34 @@ def build_vastai_cleanup_policy(
         list_instances_fn=_list_instances,
         destroy_fn=_destroy,
     )
+
+
+def _describe_destroy_result(result: DestroyResult) -> str:
+    """Build diagnostic text from v3 DestroyResult structured fields.
+
+    Handles ``None`` fields gracefully (v3 uses optional diagnostics).
+    Always produces non-empty output.
+    """
+    return (
+        f"attempts={result.attempts}, "
+        f"last_status={result.last_status_code}, "
+        f"verify_error={result.verify_error!r}, "
+        f"stop_error={result.stop_error!r}"
+    )
 ```
 
 ## Orchestrator wiring
 
 The orchestrator's `_sweep_zombies` is policy-driven end-to-end.
 The orchestrator logs every non-`DESTROYED` outcome at severity
-matching operational impact.
+matching operational impact. Unexpected `NO_CREDENTIALS` is
+`WARNING` (it means the factory's CLI fallback was bypassed and the
+orphan wasn't cleaned up).
 
 ```python
 # src/vastai_gpu_runner/batch.py (changes to _sweep_zombies)
 # NB: `logger` is the module-level logger already defined at the
-# top of batch.py (`logger = logging.getLogger(__name__)`). This
-# block shows only the new/changed logic.
+# top of batch.py (`logger = logging.getLogger(__name__)`).
 
 def _sweep_zombies(self) -> int:
     """Destroy orphaned instances not tracked by live_runners.
@@ -1260,6 +1483,16 @@ def _sweep_zombies(self) -> int:
                 candidate.instance_id,
                 result.error,
             )
+        elif result.refusal == CleanupRefusal.NO_CREDENTIALS:
+            # Should not reach here — the factory's CLI fallback
+            # intercepts NO_CREDENTIALS. Logged at WARNING because
+            # it indicates the orphan was not cleaned up.
+            logger.warning(
+                "Zombie sweep: %s unexpectedly returned NO_CREDENTIALS "
+                "after fallback handling: %s",
+                candidate.instance_id,
+                result.error,
+            )
         elif result.refusal in (
             CleanupRefusal.OWNERSHIP,
             CleanupRefusal.INELIGIBLE_STATE,
@@ -1269,14 +1502,6 @@ def _sweep_zombies(self) -> int:
                 "Zombie sweep: %s refused (%s): %s",
                 candidate.instance_id,
                 result.refusal.value,
-                result.error,
-            )
-        elif result.refusal == CleanupRefusal.NO_CREDENTIALS:
-            # Should not reach here — the factory's CLI fallback
-            # intercepts NO_CREDENTIALS. Logged for visibility.
-            logger.info(
-                "Zombie sweep: %s refused (no credentials): %s",
-                candidate.instance_id,
                 result.error,
             )
     if killed:
@@ -1291,7 +1516,9 @@ and `runner_factory: RunnerFactory`.
 
 The CLI is the one place that builds the canonical config (for the
 runner) and the two canonical objects (for the cleanup policy). It
-threads both into the v3 + v4 entry points.
+threads both into the v3 + v4 entry points. Empty
+`--allowed-images` is **fail-closed** (empty set, reject every
+image), not opt-out.
 
 ```python
 # src/vastai_gpu_runner/cli.py (new "batch" subcommand)
@@ -1313,7 +1540,6 @@ def batch(
         build_vastai_cleanup_policy,
     )
 
-    # Step 1: one canonical config, frozen, immutable.
     base = VastaiProviderConfig.from_env()
     config = replace(
         base,
@@ -1321,11 +1547,8 @@ def batch(
         ownership=OwnershipPolicy(owned_images=frozenset({image})),
     )
 
-    # Step 2: runner factory reads from the same config.
     runner_factory = lambda: VastaiRunner.from_config(config)  # noqa: E731
 
-    # Step 3: cleanup policy reads ownership + credentials from the
-    # same config (no deployment-image wrapper needed).
     cleanup_policy = build_vastai_cleanup_policy(
         ownership=config.ownership,
         credentials=config.credentials,
@@ -1339,8 +1562,8 @@ def batch(
     orch.run()
 ```
 
-The existing `cli.py:cleanup` command migrates to use the new API
-without constructing a `VastaiProviderConfig` (no deployment image):
+The existing `cli.py:cleanup` command migrates to use the new API.
+Empty `--allowed-images` is **fail-closed**:
 
 ```python
 # src/vastai_gpu_runner/cli.py (cleanup command)
@@ -1352,7 +1575,13 @@ def cleanup(
         typer.Option(
             "--allowed-images",  # canonical
             "--owned-images",     # alias
-            help="Comma-separated Docker images owned by this project",
+            help=(
+                "Comma-separated Docker images owned by this project. "
+                "Omit to opt out of the ownership check (DANGEROUS — "
+                "every instance with the label prefix is destroyed). "
+                "Pass an empty string to fail-closed (every instance "
+                "is refused; use to test the wiring without risk)."
+            ),
         ),
     ] = None,
     dry_run: Annotated[bool, typer.Option("--dry-run")] = False,
@@ -1371,11 +1600,20 @@ def cleanup(
     from vastai_gpu_runner.providers.vastai import build_vastai_cleanup_policy
 
     console = Console()
-    ownership = (
-        OwnershipPolicy(owned_images=frozenset(allowed_images.split(",")))
-        if allowed_images
-        else OwnershipPolicy()
-    )
+
+    # Distinguish None (flag omitted → opt-out) from "" (explicit empty →
+    # fail-closed). Whitespace-only entries in comma-separated input are
+    # stripped; comma-only input becomes an empty set.
+    if allowed_images is None:
+        ownership = OwnershipPolicy()
+    else:
+        images = frozenset(
+            item.strip()
+            for item in allowed_images.split(",")
+            if item.strip()
+        )
+        ownership = OwnershipPolicy(owned_images=images)
+
     cleanup_policy = build_vastai_cleanup_policy(
         ownership=ownership,
         credentials=read_vastai_api_key(),
@@ -1424,68 +1662,73 @@ Seven steps. Each step is independently testable but the rollout
 lands as one PR because the intermediate states are not stable.
 
 1. **Add canonical credential + ownership-policy types + invariants + contract tests.**
-   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with the v3 `_repository` helper; declared `_normalised` cache field).
-   - `providers/destroy_adapters/vastai.py:CredentialState` (StrEnum) + `CredentialResolution` (frozen dataclass with `state` and `key` fields).
+   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with `_repository`; declared `_normalised` cache field).
+   - `providers/destroy.py:DestroyVerdict` (StrEnum: `DESTROYED | LEAKED | UNKNOWN`), `DestroyRefusal` (StrEnum: `OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED`), `DestroyResult` (frozen dataclass with `__post_init__` invariants).
+   - `providers/destroy_adapters/vastai.py:CredentialState` (StrEnum) + `CredentialResolution` (frozen dataclass).
    - Property tests: `OwnershipPolicy.matches` is reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets and malformed references.
    - `CredentialResolution` invariants: AVAILABLE requires non-empty pre-stripped key; ABSENT and EXPLICITLY_DISABLED require empty key.
+   - `DestroyResult` invariants: exactly one of verdict/refusal, no protocol context on refusals, ≥1 attempt on verdict outcomes.
 
-2. **Add v3 `DestroyResult` / `DestroyVerdict` / `DestroyRefusal` types + amend adapter signature.**
-   - `providers/destroy_adapters/vastai.py:DestroyVerdict` (StrEnum: `DESTROYED | LEAKED | UNKNOWN`).
-   - `providers/destroy_adapters/vastai.py:DestroyRefusal` (StrEnum: `OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED`).
-   - `providers/destroy_adapters/vastai.py:DestroyResult` (frozen dataclass: `verdict | refusal`, `attempts`, `last_status_code`, `stop_error`, `verify_error` — no `error` field).
-   - `destroy_vastai_instance(instance_id, *, ownership: OwnershipPolicy, credentials: CredentialResolution | None = None) -> DestroyResult`. Back-compat: when `credentials=None`, calls `read_vastai_api_key()`.
-   - Contract tests: ownership match uses `OwnershipPolicy.matches()`; credential state drives refusal type; AVAILABLE runs the REST path; ABSENT returns `NO_CREDENTIALS`; EXPLICITLY_DISABLED returns `CREDENTIALS_DISABLED`.
+2. **Amend v3 adapter with v4 signature + env-first resolver.**
+   - `destroy_vastai_instance(instance_id, *, ownership: OwnershipPolicy, credentials: CredentialResolution | None = None) -> DestroyResult`. Back-compat: `credentials=None` calls `read_vastai_api_key()`.
+   - `read_vastai_api_key()` env-first: inspect `VASTAI_API_KEY` first (empty → `EXPLICITLY_DISABLED`, non-empty → `AVAILABLE`); fall back to file paths (blank/unreadable → warning + `ABSENT`, not disabled); catch `OSError`.
+   - Adapter tests: ownership match uses `OwnershipPolicy.matches()`; credential state drives refusal type; AVAILABLE runs the REST path; ABSENT returns `NO_CREDENTIALS`; EXPLICITLY_DISABLED returns `CREDENTIALS_DISABLED`.
 
 3. **Add Vast.ai runner + cleanup adapter.**
    - `providers/vastai.py:VastaiProviderConfig` (frozen, with `__post_init__` invariants).
    - `providers/vastai.py:VastaiRunner.from_config(canonical)` — preserves `ownership` and `credentials`.
    - `VastaiRunner.__init__` adds `ownership: OwnershipPolicy | None` + `credentials: CredentialResolution | None` parameters; rejects simultaneous `ownership=` + `allowed_images=` with `ValueError`; `allowed_images` becomes a deprecated alias.
-   - `VastaiRunner.destroy_instance` is a single `destroy_vastai_instance(...)` adapter call (no v2 regression).
-   - `verify_instance_ownership(instance_id, *, ownership: OwnershipPolicy)` — replaces `_image_is_allowed`.
-   - `list_vastai_instances()` returns `list[InstanceCandidate]`, validates `instance_id` non-empty.
+   - `VastaiRunner.destroy_instance` is a single `destroy_vastai_instance(...)` adapter call; logs the typed `DestroyResult` for non-`DESTROYED` outcomes.
+   - `verify_instance_ownership(instance_id, *, ownership: OwnershipPolicy)` — local to `providers/vastai.py`, replaces `_image_is_allowed`.
+   - `list_vastai_instances()` returns `list[InstanceCandidate]`; validates `inst` is dict, `id` is not `None`, `instance_id` is non-empty after strip.
    - `VASTAI_TERMINAL_STATES: frozenset[str]` module constant.
-   - `build_vastai_cleanup_policy(*, ownership: OwnershipPolicy, credentials: CredentialResolution) -> ProviderCleanupPolicy` — wires list + destroy callbacks.
+   - `build_vastai_cleanup_policy(*, ownership: OwnershipPolicy, credentials: CredentialResolution) -> ProviderCleanupPolicy`.
    - Adapter tests:
      - EXPLICITLY_DISABLED: `list_instances()` returns `[]` without invoking `vastai_cmd`.
-     - ABSENT CLI fallback: v3 returns `NO_CREDENTIALS` → factory runs CLI ownership verification + CLI destroy → `CLI_ATTEMPTED` (not `DESTROYED`) on command success; `UNKNOWN` on command failure.
+     - ABSENT CLI fallback: v3 returns `NO_CREDENTIALS` → factory runs CLI ownership + CLI destroy → `CLI_ATTEMPTED` (not `DESTROYED`) on command success; `UNKNOWN` on command failure.
      - AVAILABLE: v3 returns `DESTROYED` → `verdict=DESTROYED`.
-     - `verdict=LEAKED` / `verdict=UNKNOWN` translate correctly with `_describe(result)` diagnostic.
+     - `verdict=LEAKED` / `verdict=UNKNOWN` translate correctly with diagnostic.
      - `refusal=OWNERSHIP` / `NO_CREDENTIALS` / `CREDENTIALS_DISABLED` translate correctly.
-     - INELIGIBLE_STATE: candidate.state in `VASTAI_TERMINAL_STATES` → `refusal=INELIGIBLE_STATE`.
-     - PROVIDER_MISMATCH: handled by the policy's `destroy()` method, not the factory.
-     - `list_vastai_instances()` skips records with empty `instance_id`.
+     - INELIGIBLE_STATE for terminal or empty state.
+     - `list_vastai_instances()` skips dict-non, id-None, id-empty records.
+     - `ProviderCleanupPolicy.destroy()` returns `CleanupResult(verdict=UNKNOWN, error="...invalid result type...")` when `destroy_fn` returns `None` or non-`CleanupResult`.
+     - `VastaiRunner.destroy_instance` logs the typed `DestroyResult` for non-`DESTROYED` outcomes.
 
 4. **Add orchestrator support behind a fail-closed compatibility path.**
    - `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required).
    - `_sweep_zombies` is policy-driven; logs every non-`DESTROYED` outcome at severity matching operational impact.
    - Orchestrator tests:
-     - Severity logging: `LEAKED` = `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, refusals = `INFO` (verified with `caplog`).
+     - Severity logging: `LEAKED` = `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, unexpected `NO_CREDENTIALS` = `WARNING`, refusals = `INFO` (verified with `caplog`).
      - `_sweep_zombies` continues on `destroy_fn` exceptions (they return `verdict=UNKNOWN` with `type(exc).__name__: exc`).
      - `_sweep_zombies` does NOT import provider modules (verified by `inspect.getsource`).
 
 5. **Update every composition root, subclass, and existing CLI command.**
    - `cli.py:batch`: build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy(ownership, credentials)`.
-   - `cli.py:cleanup`: build `OwnershipPolicy` and `CredentialResolution` directly (no `VastaiProviderConfig`), pass to `build_vastai_cleanup_policy`.
+   - `cli.py:cleanup`: build `OwnershipPolicy` and `CredentialResolution` directly (no `VastaiProviderConfig`); distinguish `None` (opt-out) from `""` (fail-closed).
    - `cli.py:instances`: use `list_vastai_instances()` for the table. `--allowed-images` canonical, `--owned-images` alias.
    - `BatchOrchestrator` subclasses: update composition to supply `cleanup_policy`.
    - Test fixtures: `VastaiProviderConfig` + `OwnershipPolicy` + `CredentialResolution` factory fixtures.
 
 6. **Add integration tests.**
    - `tests/integration/test_cleanup_policy_integration.py`:
-     - **disabled-before-enumeration**: `credentials=EXPLICITLY_DISABLED` → `policy.list_instances()` returns `[]`; `vastai_cmd` was not called (verified by mock call count).
+     - **disabled-before-enumeration**: `credentials=EXPLICITLY_DISABLED` → `policy.list_instances()` returns `[]`; `vastai_cmd` was not called.
      - **absent-credential CLI fallback**: `credentials=ABSENT` → `policy.destroy(candidate)` returns `verdict=CLI_ATTEMPTED` (NOT `DESTROYED`); the canonical `ABSENT` resolution was passed to the REST adapter (NOT `None`).
-     - **empty ownership set**: `ownership=OwnershipPolicy(owned_images=frozenset())` → `verdict=...` → `OWNERSHIP` (fail-closed).
+     - **empty ownership set**: `ownership=OwnershipPolicy(owned_images=frozenset())` → `OWNERSHIP` (fail-closed).
      - **provider mismatch**: candidate `Provider.RUNPOD` to a Vast.ai policy → `PROVIDER_MISMATCH` with operator-friendly diagnostic.
      - **enumeration failure**: `list_vastai_instances()` raises → `policy.list_instances()` returns `[]`.
-     - **ineligible state**: candidate `state="destroyed"` → `INELIGIBLE_STATE` without invoking `destroy_vastai_instance`.
-     - **severity logging**: orchestrator logs `LEAKED` at `ERROR`, `UNKNOWN` at `WARNING`, refusals at `INFO` (verified with `caplog`).
-     - **non-empty error from empty exception**: `raise RuntimeError()` (no message) → orchestrator logs with non-empty error containing `RuntimeError: `.
-     - **empty instance_id in enumeration**: malformed Vast.ai record skipped, not passed to destroy.
+     - **ineligible state**: candidate `state="destroyed"` → `INELIGIBLE_STATE`.
+     - **severity logging**: orchestrator logs `LEAKED` at `ERROR`, `UNKNOWN` at `WARNING`, unexpected `NO_CREDENTIALS` at `WARNING`, refusals at `INFO`.
+     - **non-empty error from empty exception**: `raise RuntimeError()` → orchestrator logs with non-empty error.
+     - **null instance_id in enumeration**: JSON `{id: null, ...}` skipped, not passed to destroy.
+     - **CLI --allowed-images empty string**: fail-closed (empty set, refuses every candidate).
+     - **CLI --allowed-images None**: opt-out (every image considered owned).
+     - **destroy_fn returns None**: orchestrator receives `CleanupResult(verdict=UNKNOWN, error="...invalid result type NoneType")`.
+     - **VastaiRunner logs typed result**: LEAKED outcome produces an `ERROR`-level log line with the structured diagnostic context.
 
 7. **Delete legacy sweep + duplicated helpers after a repository-wide caller audit.**
    - `audit_caller_sites.sh` (run before deletion): grep for external callers of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use), `providers.vastai._image_is_allowed`. Update external callers.
-   - Delete `orchestrator.sweep_zombie_instances` (v3 deferral reaffirmed).
-   - Delete `orchestrator.load_vastai_api_key` (v3 deferral reaffirmed).
+   - Delete `orchestrator.sweep_zombie_instances`.
+   - Delete `orchestrator.load_vastai_api_key`.
    - Delete `providers/vastai.py:_image_is_allowed`.
    - Delete direct `vastai_cmd(["show", "instances", "--raw"])` parsing in `cli.py:cleanup` and `cli.py:instances`.
    - Update `tests/test_orchestrator.py` and `tests/test_batch.py` to mock `cleanup_policy.list_instances` and `cleanup_policy.destroy`.
@@ -1497,30 +1740,34 @@ lands as one PR because the intermediate states are not stable.
   - `OwnershipPolicy.matches`: reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets, malformed reference rejection.
   - `OwnershipPolicy._normalised`: declared field; precomputed in `__post_init__`; `matches` is O(1) per call.
   - `ProviderCleanupPolicy.list_instances`: returns wired list; catches and returns `[]` on exception.
-  - `ProviderCleanupPolicy.destroy`: provider mismatch returns `PROVIDER_MISMATCH`; catches `destroy_fn` exceptions with `f"{type(exc).__name__}: {exc}"` (non-empty even for `RuntimeError()` with no message).
+  - `ProviderCleanupPolicy.destroy`: provider mismatch returns `PROVIDER_MISMATCH`; catches `destroy_fn` exceptions with `f"{type(exc).__name__}: {exc}"` (non-empty even for `RuntimeError()` with no message); validates `destroy_fn` return is `CleanupResult` (returns `CleanupResult(verdict=UNKNOWN, ...)` on `None` or non-`CleanupResult`).
   - `CleanupResult` invariants: 5 cases (verdict/refusal exclusivity, error non-empty on non-DESTROYED, error empty on DESTROYED).
   - `InstanceCandidate.__post_init__`: empty `instance_id` raises; whitespace-only `instance_id` raises.
+- `tests/test_providers_destroy.py`:
+  - `DestroyResult` invariants: exactly one of verdict/refusal; refusal must not carry protocol context; verdict requires ≥1 attempt.
 - `tests/test_providers_vastai.py`:
-  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig` (constructor parity).
+  - `read_vastai_api_key` env-first: `VASTAI_API_KEY=""` → `EXPLICITLY_DISABLED`; `VASTAI_API_KEY="key"` → `AVAILABLE`; no env + file → `AVAILABLE`; no env + blank file → `ABSENT` (with warning); `OSError` → `ABSENT` (with warning).
+  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig`.
   - `VastaiRunner(allowed_images=frozenset({img}))` (deprecated) emits `DeprecationWarning` + builds equivalent `OwnershipPolicy`.
   - Simultaneous `ownership=` and `allowed_images=` raises `ValueError`.
   - `verify_instance_ownership` uses `OwnershipPolicy.matches()`.
-  - `list_vastai_instances` returns `list[InstanceCandidate]` with `gpu_model` + `cost_per_hour` populated; skips records with empty `instance_id`; returns `[]` on API error.
+  - `list_vastai_instances` returns `list[InstanceCandidate]` with `gpu_model` + `cost_per_hour` populated; skips records where `inst` is not a dict, `id` is `None`, `id` is empty after strip; returns `[]` on API error.
   - `build_vastai_cleanup_policy(*, ownership, credentials)`:
     - EXPLICITLY_DISABLED list: returns `[]` without `vastai_cmd`.
     - ABSENT destroy: factory intercepts `NO_CREDENTIALS` → CLI ownership verify → CLI destroy → `CLI_ATTEMPTED` (success) or `UNKNOWN` (failure).
     - AVAILABLE destroy: v3 DESTROYED → `verdict=DESTROYED`.
-    - LEAKED / UNKNOWN translate with `_describe(result)` diagnostic.
+    - LEAKED / UNKNOWN translate with `_describe_destroy_result()` diagnostic.
     - OWNERSHIP / NO_CREDENTIALS / CREDENTIALS_DISABLED translate correctly.
     - INELIGIBLE_STATE for `state in VASTAI_TERMINAL_STATES` or empty state.
+  - `VastaiRunner.destroy_instance` logs typed result: LEAKED → `ERROR`, UNKNOWN → `WARNING`, refusals → `ERROR`; returns `False`.
 - `tests/test_batch.py`:
   - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once.
   - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate.
   - `_sweep_zombies` counts only `verdict=DESTROYED` outcomes.
-  - `_sweep_zombies` logs `LEAKED` at `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` at `WARNING`, refusals at `INFO` (`caplog`).
+  - `_sweep_zombies` logs `LEAKED` at `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` at `WARNING`, unexpected `NO_CREDENTIALS` at `WARNING`, refusals at `INFO` (`caplog`).
   - `_sweep_zombies` continues on `destroy_fn` exceptions.
   - `_sweep_zombies` does NOT import provider modules (`inspect.getsource`).
-- `tests/integration/test_cleanup_policy_integration.py` — 9 scenarios from step 6 above.
+- `tests/integration/test_cleanup_policy_integration.py` — 13 scenarios from step 6 above.
 
 ## Backwards compatibility
 
@@ -1536,8 +1783,9 @@ and call `policy.destroy(candidate)`.
 
 The `cli.py:cleanup` and `cli.py:instances` commands are refactored
 in v4 step 5. The `--allowed-images` flag is preserved as canonical;
-`--owned-images` is added as a documented alias. The rename is
-deferred to a separate CLI compatibility change.
+`--owned-images` is added as a documented alias. Empty
+`--allowed-images ""` is **fail-closed** (not opt-out) — this is a
+behaviour change from the previous CLI default.
 
 ## Out of scope
 
@@ -1545,8 +1793,6 @@ deferred to a separate CLI compatibility change.
   ships (roadmap item 2). The `ProviderCleanupPolicy` interface is
   provider-agnostic from day one.
 - **Hostile detection.** Removed in the v4 second-pass review.
-  Hostile detection is deferred to a separate audit stage that
-  emits alerts without changing the destroy decision.
 - **Dispute webhook.** Future work.
 - **Bulk-destroy optimisation.** YAGNI for now.
 - **Cross-provider zombie sweep.** A single orchestrator supports
@@ -1554,13 +1800,11 @@ deferred to a separate CLI compatibility change.
 
 ## Review process
 
-This is the fourth review pass on the v4 architecture. The first
-draft was rejected with 5 BLOCKERs + 7 CONCERNs. The second draft
-was rejected with 7 BLOCKERs + 2 CONCERNs + 3 NITs. The third draft
-was rejected with 6 BLOCKERs + 4 CONCERNs + 2 NITs. This fourth
-draft addresses every finding.
+This is the fifth review pass on the v4 architecture. Each prior
+draft was rejected and addressed. This draft addresses every
+finding from the 8th-pass review.
 
-The fourth review prompt for ChatGPT-with-GitHub-plugin:
+The fifth review prompt for ChatGPT-with-GitHub-plugin:
 
 > Review the v4 architecture design at PR #22 (file:
 > docs/architecture-v4-cleanup-policy.md) against the v3 design at
@@ -1569,72 +1813,83 @@ The fourth review prompt for ChatGPT-with-GitHub-plugin:
 > src/vastai_gpu_runner/providers/vastai.py. The v4 design
 > resolves issue #19.
 >
-> The third draft was rejected with 6 BLOCKERs, 4 CONCERNs, and
-> 2 NITs. Verify each finding is addressed:
+> The fourth draft was rejected with 5 BLOCKERs and 3 CONCERNs.
+> Verify each finding is addressed:
 >
-> 1. **BLOCKER 1 (ABSENT CLI fallback)**: confirm the factory
->    intercepts `DestroyRefusal.NO_CREDENTIALS` and runs CLI
->    ownership verification + CLI destroy, returning
->    `CLI_ATTEMPTED` (not `DESTROYED`) on command success.
-> 2. **BLOCKER 2 (v3 translation)**: confirm `CLI_ATTEMPTED` is
->    NOT read from `DestroyVerdict`; confirm `_describe(result)`
->    builds diagnostic text from `attempts`, `last_status_code`,
->    `stop_error`, `verify_error`.
-> 3. **BLOCKER 3 (VastaiRunner delegation)**: confirm
->    `VastaiRunner.destroy_instance` is a single
->    `destroy_vastai_instance(...)` call; confirm `from_config`
->    preserves both `ownership` and `credentials`; confirm
->    simultaneous `ownership=` + `allowed_images=` raises
->    `ValueError`.
-> 4. **BLOCKER 4 (non-empty catch error)**: confirm the catch
->    uses `f"{type(exc).__name__}: {exc}"` so the error is
->    always non-empty.
-> 5. **BLOCKER 5 (build_vastai_cleanup_policy direct args)**:
->    confirm the factory takes `(*, ownership, credentials)`
->    directly (no `VastaiProviderConfig` wrapper); confirm the
->    cleanup CLI command does not construct a `VastaiProviderConfig`.
-> 6. **BLOCKER 6 (instance_id validation)**: confirm
->    `list_vastai_instances` skips records with empty
->    `instance_id`; confirm `InstanceCandidate.__post_init__`
->    raises `ValueError` for empty or whitespace-only IDs.
-> 7. **CONCERN 7 (_normalised declared field)**: confirm
->    `_normalised` is a `field(init=False, repr=False, compare=False)`.
-> 8. **CONCERN 8 (StrEnum for CredentialState)**: confirm
->    `CredentialState(StrEnum)` (not plain `Enum`).
-> 9. **CONCERN 9 (negative allowlist)**: confirm
->    `VASTAI_TERMINAL_STATES = frozenset({"destroyed"})` (skip
->    only terminal states); confirm new states are processed.
-> 10. **CONCERN 10 (severity logging)**: confirm `LEAKED` =
->     `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED`
->     = `WARNING`, refusals = `INFO`.
-> 11. **NIT 11 (canonical flag)**: confirm `--allowed-images` is
->     declared first in `typer.Option`; the Python parameter is
->     `allowed_images`.
-> 12. **NIT 12 (is_candidate historical)**: confirm the historical
->     change summary no longer mentions `is_candidate`.
+> 1. **BLOCKER 1 (module ownership)**: confirm
+>    `DestroyVerdict` / `DestroyRefusal` / `DestroyResult` are
+>    defined in `providers/destroy.py` (NOT in the Vast.ai
+>    adapter). Confirm `providers/vastai.py` imports them from
+>    `providers.destroy`, not from
+>    `providers.destroy_adapters.vastai`. Confirm `vastai_cmd`
+>    and `verify_instance_ownership` are local to
+>    `providers/vastai.py` (no import from the adapter).
+> 2. **BLOCKER 2 (env-first credentials)**: confirm
+>    `read_vastai_api_key()` inspects `VASTAI_API_KEY` first
+>    (empty → `EXPLICITLY_DISABLED`, non-empty → `AVAILABLE`),
+>    then falls back to file paths (blank/unreadable → warning +
+>    `ABSENT`). Confirm `OSError` is caught.
+> 3. **BLOCKER 3 (DestroyResult verbatim)**: confirm
+>    `DestroyResult` is NOT redefined in the adapter; confirm
+>    the v3 types from `providers.destroy` use optional fields
+>    and `__post_init__` invariants. Confirm `_describe()`
+>    handles `None` fields.
+> 4. **BLOCKER 4 (empty --allowed-images fail-closed)**:
+>    confirm the cleanup CLI distinguishes `None` (opt-out)
+>    from `""` (fail-closed empty set). Confirm whitespace-only
+>    entries in comma-separated input are stripped.
+> 5. **BLOCKER 5 (null ID rejected)**: confirm
+>    `list_vastai_instances` checks `inst` is a dict, then
+>    checks `inst.get("id") is None` explicitly (catches
+>    JSON `null` before `str()` converts to `"None"`).
+> 6. **CONCERN 6 (destroy_fn return validated)**: confirm
+>    `ProviderCleanupPolicy.destroy()` checks `isinstance(result,
+>    CleanupResult)` and substitutes `CleanupResult(verdict=UNKNOWN,
+>    ...)` when the callback returns `None` or non-`CleanupResult`.
+> 7. **CONCERN 7 (NO_CREDENTIALS WARNING)**: confirm unexpected
+>    `NO_CREDENTIALS` is logged at `WARNING`, not `INFO`.
+> 8. **CONCERN 8 (runner logs typed result)**: confirm
+>    `VastaiRunner.destroy_instance` logs the typed
+>    `DestroyResult` (verdict/refusal + diagnostic context)
+>    before returning `False` for non-`DESTROYED` outcomes.
 >
 > Additionally, identify any new BLOCKERs or CONCERNs introduced
-> by the fourth draft. Focus on:
-> - The factory's `_cli_fallback` ownership check: does it use
->   `verify_instance_ownership` correctly? Does the failure path
->   produce a structured refusal with non-empty error?
-> - The `_describe(result)` helper: does it handle all four
->   structured fields correctly? Are empty fields handled
->   gracefully?
-> - The `InstanceCandidate.__post_init__` invariant: does it
->   correctly reject empty strings AND whitespace-only strings?
-> - The `OwnershipPolicy._normalised` declared field: does the
->   `field(default=None)` correctly handle the case where
->   `__post_init__` doesn't override it (None ownership)?
-> - The `build_vastai_cleanup_policy` signature change from
->   `(canonical)` to `(*, ownership, credentials)`: is the
->   batch command's extraction correct? Is the cleanup command's
->   direct construction correct?
-> - The orchestrator's severity logging: does it correctly handle
->   the `verdict=None` and `refusal=None` case (defensive)?
-> - The CLI's `--allowed-images` canonical declaration: does
->   `typer.Option("--allowed-images", "--owned-images", ...)`
->   accept both flags in the right order?
+> by the fifth draft. Focus on:
+>
+> - The module boundary: does `providers/vastai.py` import
+>   `DestroyRefusal` / `DestroyResult` / `DestroyVerdict` ONLY
+>   from `providers.destroy` (and NOT from the adapter)?
+> - The env-first `read_vastai_api_key`: does the env-var
+>   branch correctly handle `os.environ.get("VASTAI_API_KEY")`
+>   returning `None` (unset), empty string, whitespace, and
+>   non-empty?
+> - The `DestroyResult.__post_init__` invariants: does
+>   `attempts >= 1` correctly accept `attempts=1`?
+> - The `_describe()` helpers (one in `providers/vastai.py`,
+>   one in the factory): are they duplicated? Should they be
+>   shared? Or are they acceptably local?
+> - The `list_vastai_instances` validation order: is the
+>   `isinstance(inst, dict)` check before `inst.get("id")`?
+>   Does the outer `try` block still catch `AttributeError`
+>   on a non-dict element?
+> - The `build_vastai_cleanup_policy` import: does the
+>   factory import `DestroyRefusal` / `DestroyResult` /
+>   `DestroyVerdict` from `providers.destroy` (NOT from the
+>   adapter)?
+> - The CLI cleanup command: does the empty `--allowed-images`
+>   handling correctly distinguish `None` vs `""` vs
+>   `","` vs `"a, ,b"`?
+> - The `VastaiRunner.destroy_instance` typed logging: is the
+>   `_describe()` call correct? Are the log levels appropriate?
+> - The orchestrator's `NO_CREDENTIALS` WARNING: does the
+>   conditional correctly handle the case where `refusal ==
+>   NO_CREDENTIALS` but `verdict is None`?
+> - The `DestroyResult` invariants and the `_describe()` helper:
+>   when `result.attempts is None` (shouldn't happen after
+>   `__post_init__`, but defensively), does `_describe()`
+>   produce non-empty output?
+> - The migration step 5: are the CLI changes correctly
+>   described?
 >
 > Return a labeled list of findings. Each finding is one of:
 > BLOCKER (must fix before merge), CONCERN (should fix, but not

--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -10,7 +10,9 @@ For the current-state architecture (today's code) see
 [`architecture-v2.md`](architecture-v2.md). For the v3 design (now
 merged but **not yet implemented**) see [`architecture-v3.md`](architecture-v3.md).
 The v3 doc's "Known limitation" section flagged this design as the
-next step.
+next step. Issue #19's fifth-pass review recommended Option B
+(canonical config) over Option A (per-runner `destroy_zombie`) — the
+v4 design implements Option B.
 
 [i19]: https://github.com/Lambda-Biolab/vastai-gpu-runner/issues/19
 
@@ -18,37 +20,81 @@ next step.
 
 In one paragraph: the ownership-guard policy used by the zombie sweep
 moves from a `VastaiRunner.allowed_images` attribute (which the
-orchestrator can only read by introspecting a runner it has no business
-constructing) to a single, immutable `ProviderCleanupPolicy` object
-that is constructed once at boot time from the same canonical provider
-config used to build the runner factory. The runner factory and the
-cleanup policy now share **one** source of truth for "what counts as
-ours" and "what to do with not-ours" — no per-destroy runner
-construction, no drift between the `destroy_instance` ownership guard
-and the zombie-sweep ownership guard. The cleanup policy is
-provider-agnostic (a frozen dataclass with two methods); the
-provider-specific bits (Vast.ai image allowlist, RunPod template-id
-whitelist, etc.) live in adapter construction functions
-(`ProviderCleanupPolicy.from_vastai_config`,
-`ProviderCleanupPolicy.from_runpod_config`). The orchestrator's
-`_sweep_zombies` calls
-`cleanup_policy.is_candidate(snapshot)` and then
-`cleanup_policy.destroy(candidate)` — it never reads
-`allowed_images` directly and never calls a provider-specific destroy
-function.
+orchestrator can only read by introspecting a runner it has no
+business constructing) to a single, immutable `ProviderCleanupPolicy`
+object that is constructed once at boot time from the same canonical
+provider config used to build the runner factory. The runner factory
+and the cleanup policy now share **one** source of truth for "what
+counts as ours" and "what to do with not-ours" — no per-destroy
+runner construction, no drift between the `destroy_instance` ownership
+guard and the zombie-sweep ownership guard. The shared ownership
+semantics live in an `OwnershipPolicy` frozen dataclass with a single
+`matches(image_ref)` method (exact reference OR tag-insensitive
+repository equality, per the v3 contract), consumed by both the
+runner and the cleanup adapter. The credential semantics live in a
+v3 `CredentialResolution` (three-state: `AVAILABLE` / `ABSENT` /
+`EXPLICITLY_DISABLED`), also shared. The `ProviderCleanupPolicy` is
+frozen (`kw_only=True`), provider-agnostic (a dataclass with two
+methods: `list_instances()` and `destroy(candidate)`), and exposes
+the destroy contract as the authoritative gate — the orchestrator
+passes every label-matching, untracked candidate to `destroy()` and
+records the `CleanupResult` (refusal or verbidden). The provider-
+specific adapters live in `providers/vastai.py` (the
+`build_vastai_cleanup_policy` factory) and, when they ship, in
+`providers/runpod.py` etc.; the core `cleanup_policy.py` module has
+provider-specific imports.
 
 Diff vs v3 once v3 is implemented:
 
-- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen dataclass), `InstanceCandidate` (frozen dataclass), `CleanupRefusal` enum (`UNOWNED | NO_CREDENTIALS | CREDENTIALS_DISABLED`), `CleanupResult` (typed return), `from_vastai_config` / `from_runpod_config` constructors
-- **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` instead of `runner_factory + allowed_images` plumbing. The `runner_factory` is preserved (still needed for `_deploy_one`); only the ownership guard moves.
-- **~** `BatchOrchestrator._sweep_zombies` calls `cleanup_policy.is_candidate(candidate)` to filter, then `cleanup_policy.destroy(candidate)` to destroy. The orchestrator no longer imports `destroy_vastai_instance` — it knows the policy, not the provider.
-- **~** `VastaiRunner.__init__` keeps `allowed_images` for the `destroy_instance` ownership guard (it is the v3-daemon guard). The `from_vastai_config(cfg)` classmethod wraps the constructor so the policy and the runner share the same `allowed_images` value.
-- **+** `providers/vastai.py:list_vastai_instances()` — read-only enumeration (returns `list[InstanceCandidate]`). The orchestrator's `_sweep_zombies` uses this instead of inlining `vastai_cmd(["show", "instances", "--raw"])`.
-- **+** `providers/runpod.py` (separate tracking issue) — RunPod adapter consisting of `RunPodRunner` plus `list_runpod_instances()` plus `ProviderCleanupPolicy.from_runpod_config()`
-- **—** `BatchOrchestrator.__init__` no longer accepts `allowed_images` directly. The CLI now constructs the policy from the canonical config and passes it to the orchestrator.
-- **—** `BatchOrchestrator._sweep_zombies` no longer calls `sweep_zombie_instances` from `orchestrator.py` — the v3-routed destroy path is replaced by `cleanup_policy.destroy`. The `orchestrator.py:sweep_zombie_instances` function is **deleted** (the v3 implementation already migrated its callers through the destroy protocol).
-- **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) is reaffirmed; canonical credential loading lives in `providers/destroy_adapters/vastai.py` and the policy constructor reads from there.
-- **—** `tests/test_orchestrator.py:SweepZombieTests` — the existing tests mock `sweep_zombie_instances` directly; those mocks move to `cleanup_policy.is_candidate` / `cleanup_policy.destroy` mocks.
+- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen), `CleanupRefusal` enum (`UNOWNED | NO_CREDENTIALS | CREDENTIALS_DISABLED`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc.)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(config)` — provider-owned factory (core module does not import provider adapters)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`
+- **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (already required; v3 design). The orchestrator calls `policy.list_instances()` and `policy.destroy(candidate)` — it never branches on `Provider`, never imports provider modules.
+- **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and the tracked-id exclusion stay on the orchestrator (per-batch scope). Every other decision (eligibility, ownership, credentials, hostile classification) is delegated to `policy.destroy()`.
+- **~** `VastaiRunner.__init__` keeps the `allowed_images` parameter for the direct-construction back-compat path. `VastaiRunner.from_config(config)` is the canonical entry point used by the CLI.
+- **—** `orchestrator.py:sweep_zombie_instances` (v3 deletion) — reaffirmed. The v4 implementation removes the last direct caller.
+- **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) — reaffirmed. Credential loading lives in `providers/destroy_adapters/vastai.py` (v3).
+- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new `VastaiProviderConfig` + `ProviderCleanupPolicy` API. The CLI no longer parses Vast.ai JSON directly.
+- **~** `tests/test_orchestrator.py` and `tests/test_batch.py` — mock `cleanup_policy.list_instances()` and `cleanup_policy.destroy()` instead of `sweep_zombie_instances`. New `tests/test_cleanup_policy.py` for the policy unit tests.
+
+## Why Option B (canonical config) over Option A (per-runner `destroy_zombie`)
+
+The issue text pivoted to Option B as primary because Option A has
+a fundamental problem: a zombie candidate is **by definition** not
+in the live-runner map, so the orchestrator cannot "use the runner
+from the tuple" — there is no runner for an orphan. The orphan is
+discovered via the provider's list endpoint and the orchestrator
+never had a `CloudRunner` for it. Option A would need to either
+(a) resurrect the runner from the candidate (which requires the
+candidate to carry the deployment config — a heavier wire), or
+(b) run a factory per zombie (which is the bug the v3 5th-pass
+review flagged).
+
+Option B avoids both: the policy is the unit of work, the runner
+factory is a deployment-time construction, and the two never
+compete for the same role. The canonical config is the single
+source of truth for both the deployment identity and the destruction
+identity.
+
+## What changes vs the v4 first draft (5th-pass review)
+
+The first draft of this doc was reviewed by ChatGPT and rejected
+with five BLOCKERs and seven CONCERNs. The full diff to the first
+draft is in `docs/architecture-v4-cleanup-policy.review-1.md`. The
+substantive changes:
+
+- **Dataclass field ordering.** Switched to `@dataclass(frozen=True, kw_only=True)` so callback fields can be required without ordering pitfalls. The first draft had `destroy_fn` required after fields with defaults — a `TypeError` on import.
+- **List-instances on the policy.** First draft called `policy.list_provider_instances()` but never defined the method. The v4.2 design adds `list_instances_fn: Callable[[], list[InstanceCandidate]]` to the policy and a public `list_instances()` method that the orchestrator calls.
+- **`is_candidate` / `destroy` split.** The first draft made `is_candidate` perform the ownership check, which the orchestrator skipped on `False` — so `destroy()` could never produce `UNOWNED` from the normal flow. The v4.2 design removes the ownership check from `is_candidate` (it is now a cheap eligibility prefilter that returns `False` for ineligible states only) and makes `destroy()` authoritative: it re-validates ownership, credentials, and eligibility every call. The orchestrator passes every label-matching, untracked candidate to `destroy()` and records the `CleanupResult`.
+- **Hostile check.** First draft placed a `hostile_check` boolean and `hostile_threshold_seconds` int on the policy, with a destructive branch above the ownership check. The check was semantically redundant — unowned candidates are refused regardless of age. v4.2 removes the hostile check from the policy (deferred to a separate audit stage that YAGNI for now).
+- **Credential model.** First draft used `api_key: str = ""` and three enum values were flattened. v4.2 uses v3's `CredentialResolution` (three-state: `AVAILABLE` / `ABSENT` / `EXPLICITLY_DISABLED`) frozen in the canonical config. `EXPLICITLY_DISABLED` short-circuits the policy before enumeration (no API/CLI calls). `ABSENT` uses the CLI fallback with CLI ownership verification (the v3 contract).
+- **Ownership semantics.** First draft used `repository_image: Optional[str]` and exact string equality. v4.2 introduces `OwnershipPolicy` with `owned_images: AbstractSet[str] | None` and `matches(image_ref)` (exact reference OR tag-insensitive repository equality, per v3). Both the runner and the cleanup adapter call `matches()`. The deployment image is required to be in `owned_images` at construction time (fail-closed).
+- **CLI wiring.** First draft used `VastaiProviderConfig.from_env().__class__(allowed_images=image)` — a fresh default config that discarded the loaded credential. v4.2 uses `dataclasses.replace(base, ...)`.
+- **Provider factories.** First draft put `from_vastai_config` / `from_runpod_config` in the core module. v4.2 moves the Vast.ai factory to `providers/vastai.py:build_vastai_cleanup_policy`. The RunPod factory is omitted entirely (lands with the RunPod adapter).
+- **State filter.** First draft's `candidate_filter` accepted only `("running", "stopped", "exited")` — too narrow. v4.2 makes `list_*_instances()` return a complete enumeration; the policy's `destroy()` applies the eligibility filter authoritatively.
+- **`CleanupResult` invariants.** First draft's `destroyed: int = 0` allowed empty results, negative values, and combinations. v4.2 adds `__post_init__` invariants: exactly one of `destroyed: bool` or `refusal: CleanupRefusal` is set; `error` is non-empty on failure; comparisons to v3 use the `DestroyVerdict` enum, not the string `"destroyed"`.
+- **Migration order.** First draft had 7 steps in a logical order but skipped the existing CLI commands and the caller audit. v4.2 reorders the steps (canonical types first, adapter before orchestrator, audit before deletion) and explicitly addresses the `cleanup` and `instances` CLI commands.
 
 ## Module taxonomy
 
@@ -57,426 +103,325 @@ protocol. The `CloudRunner` ABC, `BatchOrchestrator`, `unit_lifecycle`,
 `providers/destroy`, and `providers/destroy_adapters/vastai` are
 unchanged in shape (v3 implementation is still a prerequisite).
 
-### New: `cleanup_policy` — owns the policy + the destroy-by-policy contract
+### New: `cleanup_policy` — owns the DTOs + the generic policy class
 
-Owns: the policy dataclass (provider, repository image allowlist,
-hostile_check + threshold, optional dispute webhook), the candidate
-record (a snapshot of one enumerated instance), the refusal enum
-(safety-critical refusals before the destroy protocol runs), the
-typed result struct, the two adapter constructors. The
-`is_candidate` and `destroy` methods are the only public surface the
-orchestrator calls.
+Owns: `InstanceCandidate` (frozen DTO), `CleanupRefusal` enum,
+`CleanupResult` (typed return), `OwnershipPolicy` (frozen, shared
+ownership semantics), `ProviderCleanupPolicy` (frozen, `kw_only`,
+provider-agnostic, holds the `list_instances_fn` and `destroy_fn`
+callbacks).
 
-Does **not** own: the destroy loop shape (lives in
-`providers/destroy`), the REST callbacks (live in the adapters), the
-API key loading (lives in the adapters), the enumeration logic
-(lives in `list_*_instances` per provider), the label-prefix filter
-(stays on the orchestrator — that's the per-batch scope, not the
-per-provider identity).
+Does **not** own: provider-specific adapters (live in `providers/*`),
+REST URLs, API key paths, the destroy protocol loop (lives in
+`providers/destroy`), the enumeration logic (per provider). The
+core module imports nothing from `providers/`.
+
+### New: `providers/vastai.py:build_vastai_cleanup_policy` — Vast.ai factory
+
+The Vast.ai factory is a provider-owned function. It reads the
+canonical `VastaiProviderConfig`, wires the v3 `destroy_vastai_instance`
++ `list_vastai_instances` into the policy, and returns the configured
+`ProviderCleanupPolicy`. The factory is the single point of contact
+between the Vast.ai adapter and the generic policy.
+
+The RunPod factory is omitted from this doc — it lands with the
+RunPod adapter (roadmap item 2). The shape is defined by the
+`ProviderCleanupPolicy` interface; the orchestrator's wiring is
+provider-agnostic from day one.
 
 ## Layered design (v4)
 
 ```
 ┌─────────────────────────────────────────────────┐
 │  CLI (cli.py)                                   │  User-facing commands
-│    └── builds canonical ProviderConfig +        │
-│        ProviderCleanupPolicy once, threads      │
-│        both into the orchestrator               │
+│    └── builds VastaiProviderConfig once,        │
+│        threads it into both runner factory      │
+│        and build_vastai_cleanup_policy          │
 ├─────────────────────────────────────────────────┤
 │  BatchOrchestrator (batch.py)                   │  Phase loop + side-effect dispatchers
 │    └── accepts cleanup_policy (frozen)          │
 │    └── _sweep_zombies calls policy methods      │
+│        (list_instances, destroy); never         │
+│        branches on Provider, never imports      │
+│        provider modules                         │
 ├─────────────────────────────────────────────────┤
-│  cleanup_policy (cleanup_policy.py)             │  NEW: policy + is_candidate + destroy
-│    └── from_vastai_config / from_runpod_config  │
+│  cleanup_policy (cleanup_policy.py)             │  NEW: DTOs + generic policy
+│    └── OwnershipPolicy (matches image_ref)      │
+│    └── ProviderCleanupPolicy (kw_only, frozen)  │
 ├─────────────────────────────────────────────────┤
-│  Providers' list_*_instances()                  │  NEW: read-only enumeration
-│    └── vastai: list_vastai_instances()          │
-│    └── runpod: list_runpod_instances() (later)  │
+│  build_vastai_cleanup_policy (factory in        │  NEW: provider-owned factory
+│  providers/vastai.py)                           │
+├─────────────────────────────────────────────────┤
+│  list_vastai_instances (provider/vastai.py)     │  NEW: read-only enumeration
 ├─────────────────────────────────────────────────┤
 │  unit_lifecycle (unit_lifecycle.py)             │  v3: decision tree, no side effects
 ├─────────────────────────────────────────────────┤
 │  providers/destroy (providers/destroy.py)       │  v3: belt-and-suspenders protocol
-│    └── belt_and_suspenders(stop_fn, delete_fn,  │
-│        verify_fn, *, policy: DestroyPolicy)     │
 ├─────────────────────────────────────────────────┤
 │  providers/destroy_adapters/vastai.py           │  v3: Vast.ai REST callbacks + policy
-│  providers/destroy_adapters/runpod.py           │  LATER: RunPod callbacks + policy
 ├─────────────────────────────────────────────────┤
 │  CloudRunner (runner.py) ── Lane A ABC          │  Provider-agnostic lifecycle
 ├──────────────┬──────────────┬───────────────────┤
 │ VastaiRunner │ RunPodRunner │ LocalRunner       │  Lane A implementations
-├──────────────┴──────────────┴───────────────────┤
-│  SSH (ssh.py)      — used by Vast.ai, RunPod    │
-│  subprocess        — used by Local              │
-└─────────────────────────────────────────────────┘
+└──────────────┴──────────────┴───────────────────┘
 ```
 
-## `ProviderCleanupPolicy` shape
+## `OwnershipPolicy` shape
 
-Single public class, frozen dataclass, two methods, three refusal
-enum members, one typed result. Adapter constructors are classmethods.
+Single frozen dataclass, owned by `cleanup_policy.py`. The v3
+ownership semantics (exact reference OR tag-insensitive repository
+equality) live here, in one method, consumed by both the runner
+and the cleanup adapter.
 
 ```python
 # src/vastai_gpu_runner/cleanup_policy.py
 from __future__ import annotations
 
-import logging
+import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import TYPE_CHECKING, Callable, Optional
-
-from vastai_gpu_runner.providers.destroy import (
-    DestroyPolicy,
-    DestroyResult,
-    DestroyRefusal,
-    belt_and_suspenders,
-)
-from vastai_gpu_runner.providers.destroy_adapters.vastai import (
-    VASTAI_POLICY,
-    destroy_vastai_instance,
-    read_vastai_api_key,
-)
-
-if TYPE_CHECKING:
-    from vastai_gpu_runner.types import Provider
-
-logger = logging.getLogger(__name__)
+from typing import AbstractSet
 
 
-class CleanupRefusal(Enum):
-    """Pre-protocol refusal reasons returned by ``cleanup_policy.destroy``.
+# Tag-insensitive repository match: strip the tag and (optional) registry,
+# then require equality. Prevents the v3 failure modes
+# ("myorg/app:1.0" matches "myorg/app-malicious:latest"; "registry:5000/myorg/app"
+# matches "registry-malicious/myorg/app").
+_TAG_RE = re.compile(r"[:@]")
 
-    The destroy protocol is *not* entered when a refusal is returned —
-    the policy has decided the candidate is not eligible for the
-    per-provider destroy path. The orchestrator logs the refusal and
-    skips the candidate.
+
+def _repository(image_ref: str) -> str:
+    """Return the tag-insensitive repository name from an image reference.
+
+    Strips the tag (`repo:tag` → `repo`) and the registry prefix
+    (`registry:5000/repo` → `repo`). The result is the canonical
+    "this image, regardless of tag or registry" name.
     """
-
-    UNOWNED = "unowned"          # image/template not in the allowlist
-    NO_CREDENTIALS = "no_credentials"  # no API key, no CLI fallback
-    CREDENTIALS_DISABLED = "credentials_disabled"  # API key explicitly empty
+    ref = image_ref.strip()
+    if not ref:
+        return ""
+    # sha256 digests: strip the @sha256:...; treat the digest as authoritative —
+    # if the digest matches, the image matches; the tag is irrelevant.
+    if "@sha256:" in ref:
+        return ref
+    # No tag ('' OR ''): nothing to strip.
+    if ":" not in ref.split("/")[-1]:
+        return ref
+    # Strip the first : after the last / (the tag separator).
+    last_slash = ref.rfind("/")
+    if last_slash == -1:
+        return ref
+    head = ref[:last_slash]
+    tail = ref[last_slash + 1 :]
+    return f"{head}/{tail.split(':', 1)[0]}"
 
 
 @dataclass(frozen=True)
-class InstanceCandidate:
-    """Read-only snapshot of one instance returned by ``list_*_instances``.
+class OwnershipPolicy:
+    """Shared ownership semantics — runner and cleanup adapter both call this.
 
-    Frozen dataclass so the policy can be stored alongside the
-    candidate in a temporary log without aliasing issues. Fields are
-    the union of what every provider can feasibly expose — providers
-    that do not have a field (e.g. RunPod has no ``image_uuid``)
-    leave it empty.
-    """
-
-    provider: "Provider"
-    instance_id: str
-    image_uuid: str          # Vast.ai: image tag; RunPod: template id
-    label: str
-    state: str               # raw provider state ("running", "stopped", ...)
-    started_at: float = 0.0  # unix epoch; 0 if unknown
-
-
-@dataclass(frozen=True)
-class CleanupResult:
-    """Outcome of ``cleanup_policy.destroy``.
-
-    Exactly one of ``destroyed`` (int) or ``refusal`` (CleanupRefusal)
-    is set. ``destroyed == 1`` means the destroy protocol succeeded;
-    ``destroyed == 0`` means the protocol ran but did not confirm
-    destruction (the daemon may have rejected the request, the
-    instance may have already been gone, etc.). A refusal is a
-    pre-protocol decision — the daemon was never contacted.
-    """
-
-    destroyed: int = 0
-    refusal: Optional[CleanupRefusal] = None
-    error: str = ""          # human-readable on protocol failure
-
-
-@dataclass(frozen=True)
-class ProviderCleanupPolicy:
-    """Per-provider cleanup contract.
-
-    Constructed once at boot time from the same canonical provider
-    config that builds the runner factory. Both the factory and the
-    policy read from the same frozen source — no per-destroy runner
-    construction, no drift between ``destroy_instance``'s ownership
-    guard and the zombie sweep's ownership guard.
+    The v3 design requires image matching to be exact reference OR
+    tag-insensitive repository equality. This dataclass encodes that
+    contract in one place. The runner's `destroy_instance` ownership
+    guard and the cleanup policy's `destroy` ownership refusal both
+    consume the same `matches()` method.
 
     Args:
-        provider: Which provider this policy applies to.
-        repository_image: The single image (or template id, for
-            RunPod) the project owns. ``None`` opts out of the
-            ownership guard (the policy still runs but accepts every
-            candidate). This is the sole configuration knob for
-            "what counts as ours."
-        hostile_check: Whether the policy should refuse to destroy
-            instances older than ``hostile_threshold_seconds`` that
-            are not in the allowlist. Default False (back-compat).
-        hostile_threshold_seconds: Threshold for the hostile check.
-        destroy_fn: Callable that takes an ``InstanceCandidate`` and
-            returns a ``CleanupResult``. Wired by the adapter
-            constructor. The orchestrator never calls this directly —
-            it calls ``policy.destroy(candidate)``.
-        candidate_filter: Callable that takes an ``InstanceCandidate``
-            and returns True if the candidate is eligible for the
-            destroy path. Default: always True. The label-prefix
-            filter is the orchestrator's responsibility, not the
-            policy's.
+        owned_images: Set of Docker image references owned by this
+            project. ``None`` explicitly disables the ownership
+            check (every image is considered owned). An empty set
+            is distinct from ``None`` — it means the project owns
+            no images and every ownership check fails (fail-closed).
 
-    Why a ``destroy_fn`` callback instead of static protocol knowledge:
-    the v3 destroy protocol is generic (`stop_fn`, `delete_fn`,
-    `verify_fn` callbacks). The cleanup policy is the next layer up —
-    it owns the decision of "should we destroy this?" and delegates
-    the "how" to the v3 protocol via the adapter-supplied callback.
-    This keeps the v3 module policy-agnostic and the cleanup_policy
-    module agnostic of REST URLs.
+    Invariants:
+        - ``owned_images`` is preserved as a frozenset (caller
+          mutation is impossible).
+        - ``None`` and ``frozenset()`` are distinct: ``None`` opts
+          out, ``frozenset()`` opts in but rejects everything.
     """
 
-    provider: "Provider"
-    repository_image: Optional[str] = None
-    hostile_check: bool = False
-    hostile_threshold_seconds: int = 300
-    destroy_fn: Callable[[InstanceCandidate], CleanupResult] = field(
-        repr=False, compare=False
-    )
-    candidate_filter: Callable[[InstanceCandidate], bool] = field(
-        default=lambda _: True, repr=False, compare=False
-    )
+    owned_images: AbstractSet[str] | None = None
 
-    def is_candidate(self, candidate: InstanceCandidate) -> bool:
-        """Return True if this candidate is eligible for the destroy path.
+    def __post_init__(self) -> None:
+        if self.owned_images is not None:
+            # Coerce to frozenset; freeze the field.
+            object.__setattr__(self, "owned_images", frozenset(self.owned_images))
 
-        Applies ``candidate_filter`` first (cheap per-provider
-        rejection — e.g. ``state not in ("running", "stopped")``),
-        then the ownership guard (image/template matches
-        ``repository_image``), then the hostile check (if enabled
-        and the candidate is older than the threshold and is not
-        in the allowlist, refuse even if the filter passes).
+    def matches(self, image_ref: str) -> bool:
+        """Return True if ``image_ref`` is owned by this policy.
 
-        The orchestrator calls this for every enumerated instance
-        before calling ``destroy``.
+        Returns True unconditionally when ``owned_images is None``
+        (ownership check disabled). Otherwise returns True iff
+        the image reference OR its tag-insensitive repository
+        matches an entry in ``owned_images``.
         """
-        if not self.candidate_filter(candidate):
-            return False
-        if self.repository_image is None:
+        if self.owned_images is None:
             return True
-        if candidate.image_uuid == self.repository_image:
+        if not image_ref:
+            return False
+        if image_ref in self.owned_images:
+            return True
+        repo = _repository(image_ref)
+        if repo and repo in self.owned_images:
             return True
         return False
+```
 
-    def destroy(self, candidate: InstanceCandidate) -> CleanupResult:
-        """Run the per-provider destroy on one candidate.
+## `CredentialResolution` shape
 
-        Handles the hostile-check refusal (when enabled), the
-        ownership refusal (when ``repository_image`` is set and the
-        candidate does not match), and delegates the actual
-        destroy protocol to ``destroy_fn``.
+The v3 design defines `CredentialResolution` in
+`providers/destroy_adapters/vastai.py`. The v4 design pulls it into
+the canonical config as-is, since v3 implementation is a prerequisite
+for v4.
 
-        Never raises. The orchestrator must be able to log the
-        result and continue to the next candidate.
-        """
-        if self.hostile_check:
-            age = candidate.started_at and (
-                _now() - candidate.started_at
-            )
-            if age > self.hostile_threshold_seconds:
-                if not self.is_candidate(candidate):
-                    logger.warning(
-                        "Cleanup: REFUSED hostile candidate %s (age=%ds, image=%s)",
-                        candidate.instance_id,
-                        int(age),
-                        candidate.image_uuid,
-                    )
-                    return CleanupResult(
-                        refusal=CleanupRefusal.UNOWNED,
-                        error=f"hostile: older than {self.hostile_threshold_seconds}s",
-                    )
-        if self.repository_image is not None and not self.is_candidate(candidate):
-            return CleanupResult(
-                refusal=CleanupRefusal.UNOWNED,
-                error=f"image {candidate.image_uuid!r} not in {self.repository_image!r}",
-            )
-        try:
-            return self.destroy_fn(candidate)
-        except Exception as exc:
-            logger.warning(
-                "Cleanup: destroy_fn raised for %s: %s",
-                candidate.instance_id,
-                exc,
-            )
-            return CleanupResult(destroyed=0, error=str(exc))
-
-    # -- Adapter constructors --------------------------------------------
-
-    @classmethod
-    def from_vastai_config(
-        cls,
-        canonical_config: "VastaiProviderConfig",
-    ) -> "ProviderCleanupPolicy":
-        """Build a Vast.ai cleanup policy from the canonical config.
-
-        The canonical config (proposed shape: a frozen dataclass on
-        ``VastaiProviderConfig`` with ``allowed_images``,
-        ``api_key``, ``hostile_check``, ``hostile_threshold_seconds``)
-        is already the source of truth for the runner factory.
-        Reading from the same source guarantees the destroy
-        ownership guard and the runner's ownership guard cannot
-        drift.
-        """
-        from vastai_gpu_runner.providers.vastai import list_vastai_instances
-
-        def _destroy(candidate: InstanceCandidate) -> CleanupResult:
-            # Pre-protocol refusal: credentials explicitly disabled.
-            if canonical_config.api_key == "":
-                return CleanupResult(
-                    refusal=CleanupRefusal.CREDENTIALS_DISABLED,
-                    error="VASTAI_API_KEY explicitly empty",
-                )
-            # The v3 destroy_vastai_instance handles the ownership
-            # guard + the belt-and-suspenders protocol. Translate
-            # its DestroyResult into a CleanupResult.
-            result = destroy_vastai_instance(
-                candidate.instance_id,
-                allowed_images=frozenset({canonical_config.allowed_images})
-                if canonical_config.allowed_images else None,
-            )
-            if result.refusal == DestroyRefusal.OWNERSHIP:
-                return CleanupResult(
-                    refusal=CleanupRefusal.UNOWNED,
-                    error=result.error,
-                )
-            if result.refusal == DestroyRefusal.NO_CREDENTIALS:
-                return CleanupResult(
-                    refusal=CleanupRefusal.NO_CREDENTIALS,
-                    error=result.error,
-                )
-            if result.verdict == "destroyed":
-                return CleanupResult(destroyed=1)
-            return CleanupResult(destroyed=0, error=result.error)
-
-        def _candidate_filter(candidate: InstanceCandidate) -> bool:
-            return candidate.state in ("running", "stopped", "exited")
-
-        return cls(
-            provider=canonical_config.provider,
-            repository_image=canonical_config.allowed_images,
-            hostile_check=canonical_config.hostile_check,
-            hostile_threshold_seconds=canonical_config.hostile_threshold_seconds,
-            destroy_fn=_destroy,
-            candidate_filter=_candidate_filter,
-        )
-
-    @classmethod
-    def from_runpod_config(
-        cls,
-        canonical_config: "RunPodProviderConfig",
-    ) -> "ProviderCleanupPolicy":
-        """Build a RunPod cleanup policy from the canonical config.
-
-        Lands when the RunPod adapter ships (roadmap item 2). The
-        shape mirrors ``from_vastai_config`` so the orchestrator's
-        `_sweep_zombies` code is identical regardless of provider.
-        """
-        # Implementation deferred to the RunPod ship PR.
-        raise NotImplementedError(
-            "RunPod adapter lands in the RunPod ship PR (roadmap item 2)"
-        )
+```python
+# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py (v3 shape)
+class CredentialResolution(Enum):
+    AVAILABLE = "available"
+    ABSENT = "absent"
+    EXPLICITLY_DISABLED = "explicitly_disabled"
 
 
-def _now() -> float:
-    """Wall-clock now in unix seconds. Wrapped for test injection."""
-    import time
-    return time.time()
+@dataclass(frozen=True)
+class CredentialResolutionResult:
+    """Output of ::func::`read_vastai_api_key`. EMPTY unless state is AVAILABLE."""
+    state: CredentialResolution
+    api_key: str = ""
+
+    def __post_init__(self) -> None:
+        if self.state == CredentialResolution.AVAILABLE:
+            assert self.api_key, "AVAILABLE requires non-empty api_key"
+        else:
+            assert not self.api_key, f"{self.state.value} requires empty api_key"
 ```
 
 ## `VastaiProviderConfig` shape
 
 The canonical config is a frozen dataclass that owns both the
 runner-side and the policy-side configuration. The runner factory
-and the cleanup policy constructor both read from it. This is the
+and the cleanup-policy factory both read from it. This is the
 "share one canonical config" pattern the v3 5th-pass review
 recommended.
 
 ```python
-# src/vastai_gpu_runner/providers/vastai.py (additions)
+# src/vastai_gpu_runner/providers/vastai.py
 @dataclass(frozen=True)
 class VastaiProviderConfig:
-    """Canonical Vast.ai configuration shared by runner factory + policy.
+    """Canonical Vast.ai configuration shared by runner factory + cleanup policy.
 
     Both ``VastaiRunner.from_config(config)`` and
-    ``ProviderCleanupPolicy.from_vastai_config(config)`` read from
-    this. The same instance is passed to both at boot time, so the
-    ownership guard cannot drift between the runner's
-    ``destroy_instance`` and the policy's ``destroy`` method.
+    ``build_vastai_cleanup_policy(config)`` read from this. The
+    same instance is passed to both at boot time, so the ownership
+    guard, the credential state, and the deployment identity cannot
+    drift.
+
+    Invariants:
+        - ``docker_image`` is in ``ownership.owned_images`` unless
+          ``ownership.owned_images is None`` (ownership check disabled).
+        - ``credentials`` is a v3 ``CredentialResolutionResult`` (frozen).
     """
 
-    provider: Provider = Provider.VASTAI
-    allowed_images: Optional[str] = None  # single image — the project's
     docker_image: str = DEFAULT_IMAGE
+    ownership: OwnershipPolicy = field(default_factory=OwnershipPolicy)
+    credentials: CredentialResolutionResult = field(
+        default_factory=lambda: CredentialResolutionResult(
+            state=CredentialResolution.ABSENT,
+        )
+    )
     min_gpu_vram_mib: int = MIN_GPU_VRAM_MIB
     setup_commands: tuple[str, ...] = ()
-    api_key: str = ""                     # read once at boot
-    hostile_check: bool = False
-    hostile_threshold_seconds: int = 300
+
+    def __post_init__(self) -> None:
+        if self.ownership.owned_images is not None:
+            if (
+                self.docker_image
+                and not self.ownership.matches(self.docker_image)
+            ):
+                msg = (
+                    f"VastaiProviderConfig invariant violated: "
+                    f"docker_image={self.docker_image!r} is not in "
+                    f"ownership.owned_images={set(self.ownership.owned_images)!r}"
+                )
+                raise ValueError(msg)
 
     @classmethod
-    def from_env(cls) -> "VastaiProviderConfig":
+    def from_env(
+        cls,
+        *,
+        docker_image: str | None = None,
+        owned_images: AbstractSet[str] | None = None,
+    ) -> "VastaiProviderConfig":
         """Build from environment / config files.
 
-        Reads the canonical Vast.ai API key path
-        (``read_vastai_api_key`` from v3) and the project's
-        canonical image from env var
-        (``VASTAI_PROJECT_IMAGE``) — the image is a single
-        canonical value, not a set, because the project owns
-        one image per provider.
+        Reads the canonical Vast.ai API key path (the v3
+        ``read_vastai_api_key``) and the env-var defaults. The
+        CLI uses ``dataclasses.replace`` to overlay the
+        project-specific values on top of this base.
         """
-        import os
         from vastai_gpu_runner.providers.destroy_adapters.vastai import (
             read_vastai_api_key,
         )
-        return cls(api_key=read_vastai_api_key())
+        return cls(
+            docker_image=docker_image or DEFAULT_IMAGE,
+            ownership=OwnershipPolicy(owned_images=owned_images),
+            credentials=read_vastai_api_key(),
+        )
 
 
 class VastaiRunner(CloudRunner):
     # ... existing constructor preserved for direct callers ...
+    def __init__(
+        self,
+        config: DeploymentConfig | None = None,
+        *,
+        allowed_images: frozenset[str] | None = None,
+        docker_image: str = DEFAULT_IMAGE,
+        min_gpu_vram_mib: int = MIN_GPU_VRAM_MIB,
+        setup_commands: list[str] | None = None,
+    ) -> None:
+        super().__init__(config)
+        self.allowed_images = allowed_images
+        self.docker_image = docker_image
+        self.min_gpu_vram_mib = min_gpu_vram_mib
+        self._setup_commands = setup_commands or []
 
     @classmethod
-    def from_config(cls, config: VastaiProviderConfig) -> "VastaiRunner":
+    def from_config(cls, canonical: VastaiProviderConfig) -> "VastaiRunner":
         """Build a VastaiRunner from the canonical config.
 
         Preserves the existing constructor as a back-compat path —
-        direct callers that build the runner by hand (unit tests,
-        scripts) keep working. The CLI uses this classmethod.
+        direct callers (unit tests, scripts) keep working. The CLI
+        uses this classmethod.
         """
         return cls(
-            allowed_images=frozenset({config.allowed_images})
-            if config.allowed_images else None,
-            docker_image=config.docker_image,
-            min_gpu_vram_mib=config.min_gpu_vram_mib,
-            setup_commands=list(config.setup_commands),
+            allowed_images=(
+                frozenset(canonical.ownership.owned_images)
+                if canonical.ownership.owned_images is not None
+                else None
+            ),
+            docker_image=canonical.docker_image,
+            min_gpu_vram_mib=canonical.min_gpu_vram_mib,
+            setup_commands=list(canonical.setup_commands),
         )
 ```
 
 ## `list_vastai_instances` shape
 
-The v3 design's destroy module owns the destroy protocol; the v4
-design adds the read-only enumeration helper that the orchestrator
-uses to discover zombies. The helper returns
-`list[InstanceCandidate]` so the orchestrator never touches raw
-provider dicts.
+The provider's read-only enumeration helper. The orchestrator's
+`_sweep_zombies` calls `policy.list_instances()` (which delegates
+to the wired `list_instances_fn`); the orchestrator never parses
+Vast.ai JSON directly.
 
 ```python
-# src/vastai_gpu_runner/providers/vastai.py (additions)
+# src/vastai_gpu_runner/providers/vastai.py
 def list_vastai_instances() -> list[InstanceCandidate]:
     """Read-only enumeration of Vast.ai instances on this account.
 
-    Returns InstanceCandidate records (provider-agnostic DTOs) so the
-    orchestrator's zombie sweep does not have to parse Vast.ai's
-    JSON shape. A failure to enumerate returns an empty list — the
-    orchestrator's existing exception handling logs the failure and
-    continues.
+    Returns ``InstanceCandidate`` records (provider-agnostic DTOs)
+    so the orchestrator's zombie sweep does not have to parse
+    Vast.ai's JSON shape. A failure to enumerate returns an empty
+    list — the orchestrator's existing exception handling logs the
+    failure and continues.
     """
     from vastai_gpu_runner.cleanup_policy import InstanceCandidate
     try:
@@ -499,15 +444,245 @@ def list_vastai_instances() -> list[InstanceCandidate]:
                 )
             )
         except (TypeError, ValueError) as exc:
-            logger.debug("Skipping malformed instance: %s", exc)
+            logger.warning("Skipping malformed instance: %s", exc)
     return candidates
+```
+
+## `ProviderCleanupPolicy` shape
+
+The core policy dataclass. Frozen, `kw_only=True`, provider-agnostic.
+Holds two callbacks (`list_instances_fn` and `destroy_fn`) that
+the provider-owned factory wires. The orchestrator calls only
+`list_instances()` and `destroy(candidate)`.
+
+```python
+# src/vastai_gpu_runner/cleanup_policy.py
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vastai_gpu_runner.providers.destroy import DestroyResult
+    from vastai_gpu_runner.types import Provider
+
+
+class CleanupRefusal(Enum):
+    """Pre-protocol refusal reasons returned by ``policy.destroy``.
+
+    These are policy-level decisions — the destroy protocol is
+    never entered. The orchestrator logs the refusal and skips
+    the candidate.
+    """
+
+    UNOWNED = "unowned"
+    NO_CREDENTIALS = "no_credentials"
+    CREDENTIALS_DISABLED = "credentials_disabled"
+
+
+@dataclass(frozen=True)
+class InstanceCandidate:
+    """Read-only snapshot of one instance returned by ``list_*_instances``.
+
+    Frozen so the policy can hold it without aliasing surprises.
+    Fields are the union of what every provider can feasibly
+    expose — providers that do not have a field (e.g. RunPod has
+    no ``image_uuid``) leave it empty.
+    """
+
+    provider: "Provider"
+    instance_id: str
+    image_uuid: str
+    label: str
+    state: str
+    started_at: float = 0.0
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Outcome of ``policy.destroy``.
+
+    Exactly one of ``destroyed`` (True) or ``refusal`` is set.
+    ``error`` is non-empty on refusal or protocol failure, empty
+    on success. The v4 design does not return the v3
+    ``DestroyResult`` directly — the policy wraps the v3 verdict
+    in a tighter one-of shape for the orchestrator.
+    """
+
+    destroyed: bool = False
+    refusal: Optional[CleanupRefusal] = None
+    error: str = ""
+
+    def __post_init__(self) -> None:
+        if self.destroyed and self.refusal is not None:
+            msg = "CleanupResult: destroyed=True and refusal=... are mutually exclusive"
+            raise ValueError(msg)
+        if not self.destroyed and self.refusal is None and not self.error:
+            msg = "CleanupResult: refusal=None requires either destroyed=True or error set"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderCleanupPolicy:
+    """Per-provider cleanup contract.
+
+    The core module is provider-agnostic: it imports nothing from
+    ``providers/``. The ``list_instances_fn`` and ``destroy_fn``
+    callbacks are wired by the provider-owned factory (e.g.
+    ``build_vastai_cleanup_policy``).
+
+    Args:
+        provider: Which provider this policy applies to.
+        ownership: Shared ownership semantics. The runner and the
+            cleanup adapter both call ``ownership.matches(image_ref)``.
+        list_instances_fn: Callable that returns a complete
+            ``list[InstanceCandidate]``. Wired by the adapter.
+        destroy_fn: Callable that takes one ``InstanceCandidate``,
+            applies the eligibility / ownership / credential /
+            hostile checks authoritatively, and returns a
+            ``CleanupResult``. The factory wires the v3
+            ``destroy_vastai_instance`` (with CLI fallback) here.
+
+    Why two callbacks (list + destroy) and not one: the
+    orchestrator's outer loop separates enumeration from
+    destruction per candidate. The destroy path needs to be
+    callable without re-enumerating (the candidate was already
+    selected). One callback per phase keeps the contract narrow.
+    """
+
+    provider: "Provider"
+    ownership: OwnershipPolicy
+    list_instances_fn: Callable[[], list[InstanceCandidate]] = field(repr=False)
+    destroy_fn: Callable[[InstanceCandidate], CleanupResult] = field(repr=False)
+
+    def list_instances(self) -> list[InstanceCandidate]:
+        """Read-only enumeration of provider instances.
+
+        The orchestrator's ``_sweep_zombies`` calls this once per
+        sweep. Failures are caught and logged by the orchestrator.
+        """
+        try:
+            return self.list_instances_fn()
+        except Exception as exc:
+            logger.warning("Cleanup policy: list_instances raised: %s", exc)
+            return []
+
+    def destroy(self, candidate: InstanceCandidate) -> CleanupResult:
+        """Run the per-provider destroy on one candidate.
+
+        Authoritative gate: this method re-validates the
+        candidate's ownership, eligibility, and credential state
+        on every call. The orchestrator must call this for every
+        label-matching, untracked candidate so refusals are
+        observable and loggable.
+
+        Never raises. The orchestrator must be able to log the
+        result and continue to the next candidate.
+        """
+        if candidate.provider != self.provider:
+            return CleanupResult(
+                refusal=CleanupRefusal.UNOWNED,
+                error=f"provider mismatch: {candidate.provider} != {self.provider}",
+            )
+        try:
+            return self.destroy_fn(candidate)
+        except Exception as exc:
+            logger.warning(
+                "Cleanup: destroy_fn raised for %s: %s",
+                candidate.instance_id,
+                exc,
+            )
+            return CleanupResult(error=str(exc))
+```
+
+## `build_vastai_cleanup_policy` shape
+
+The provider-owned factory. This is the only place that combines
+v3's `destroy_vastai_instance` with the v4 policy. It lives in
+`providers/vastai.py` (not `cleanup_policy.py`) so the core module
+never imports provider adapters.
+
+```python
+# src/vastai_gpu_runner/providers/vastai.py
+def build_vastai_cleanup_policy(
+    canonical: VastaiProviderConfig,
+) -> ProviderCleanupPolicy:
+    """Build a Vast.ai cleanup policy from the canonical config.
+
+    The canonical config (the same `VastaiProviderConfig` passed
+    to `VastaiRunner.from_config`) is the source of truth for the
+    ownership policy, the credential resolution, and the deployment
+    identity. Reading from the same source guarantees the destroy
+    ownership guard and the runner's ownership guard cannot drift.
+
+    The wired ``destroy_fn`` enforces the v3 contract:
+    - ``EXPLICITLY_DISABLED`` → ``CleanupResult(refusal=CREDENTIALS_DISABLED)``
+      without invoking CLI enumeration.
+    - ``AVAILABLE`` → v3 ``destroy_vastai_instance`` with the
+      REST bearer key.
+    - ``ABSENT`` → v3 CLI fallback (with CLI ownership verification,
+      per v3 contract).
+    """
+    from vastai_gpu_runner.cleanup_policy import (
+        CleanupRefusal,
+        CleanupResult,
+        OwnershipPolicy,
+        ProviderCleanupPolicy,
+    )
+    from vastai_gpu_runner.providers.destroy import (
+        DestroyRefusal,
+        DestroyVerdict,
+    )
+    from vastai_gpu_runner.providers.destroy_adapters.vastai import (
+        VASTAI_POLICY,
+        destroy_vastai_instance,
+    )
+
+    def _destroy(candidate: InstanceCandidate) -> CleanupResult:
+        # Pre-protocol refusal: credentials explicitly disabled.
+        # No enumeration, no CLI fallback — v3 contract.
+        if canonical.credentials.state == CredentialResolution.EXPLICITLY_DISABLED:
+            return CleanupResult(
+                refusal=CleanupRefusal.CREDENTIALS_DISABLED,
+                error="VASTAI_API_KEY explicitly empty",
+            )
+        # The v3 destroy_vastai_instance handles the ownership
+        # guard + the belt-and-suspenders protocol. Translate its
+        # DestroyResult into a CleanupResult.
+        result = destroy_vastai_instance(
+            candidate.instance_id,
+            allowed_images=(
+                frozenset(canonical.ownership.owned_images)
+                if canonical.ownership.owned_images is not None
+                else None
+            ),
+        )
+        if result.refusal == DestroyRefusal.OWNERSHIP:
+            return CleanupResult(
+                refusal=CleanupRefusal.UNOWNED,
+                error=result.error,
+            )
+        if result.refusal == DestroyRefusal.NO_CREDENTIALS:
+            return CleanupResult(
+                refusal=CleanupRefusal.NO_CREDENTIALS,
+                error=result.error,
+            )
+        if result.verdict == DestroyVerdict.DESTROYED:
+            return CleanupResult(destroyed=True)
+        return CleanupResult(error=result.error or "destroy protocol did not confirm")
+
+    return ProviderCleanupPolicy(
+        provider=canonical.docker_image and Provider.VASTAI or Provider.VASTAI,
+        ownership=canonical.ownership,
+        list_instances_fn=list_vastai_instances,
+        destroy_fn=_destroy,
+    )
 ```
 
 ## Orchestrator wiring
 
-The orchestrator's `_sweep_zombies` becomes policy-driven. The
-provider-specific destroy call is gone; the orchestrator only knows
-the policy.
+The orchestrator's `_sweep_zombies` becomes policy-driven end-to-end.
+The provider-specific destroy call is gone; the orchestrator only
+knows the policy.
 
 ```python
 # src/vastai_gpu_runner/batch.py (changes to _sweep_zombies)
@@ -515,32 +690,31 @@ def _sweep_zombies(self) -> int:
     """Destroy orphaned instances not tracked by live_runners.
 
     Routes through the cleanup policy:
-    1. Enumerate instances via the provider's list_*_instances().
+    1. Enumerate instances via ``policy.list_instances()``.
     2. Filter by label prefix (orchestrator's per-batch scope).
     3. Exclude tracked IDs (the existing semantics).
-    4. For each candidate, ask the policy if it's a candidate.
-    5. For each candidate, call policy.destroy(candidate).
-    6. Count destroyed == 1 outcomes.
+    4. For every remaining candidate, call ``policy.destroy(candidate)``.
+    5. Count ``destroyed == True`` outcomes.
+    6. Log refusals for visibility.
+
+    The orchestrator does NOT branch on Provider, does NOT import
+    provider modules, and does NOT call any provider-specific
+    destroy function. The policy owns the eligibility /
+    ownership / credential / hostile decisions.
     """
     with self._state_lock:
         tracked_ids = {
             entry[1].instance_id for entry in self._live_runners.values()
         }
-    try:
-        candidates = self._cleanup_policy.list_provider_instances()
-    except Exception as exc:
-        logger.warning("Zombie sweep: enumeration failed: %s", exc)
-        return 0
+    candidates = self._cleanup_policy.list_instances()
     killed = 0
     for candidate in candidates:
         if not candidate.label.startswith(self._label_prefix):
             continue
         if candidate.instance_id in tracked_ids:
             continue
-        if not self._cleanup_policy.is_candidate(candidate):
-            continue
         result = self._cleanup_policy.destroy(candidate)
-        if result.destroyed == 1:
+        if result.destroyed:
             killed += 1
         elif result.refusal is not None:
             logger.info(
@@ -554,17 +728,14 @@ def _sweep_zombies(self) -> int:
     return killed
 ```
 
-The orchestrator no longer imports `sweep_zombie_instances` from
-`orchestrator.py`. The orchestrator's `__init__` now requires
-`cleanup_policy: ProviderCleanupPolicy` and `runner_factory:
-RunnerFactory`. The `runner_factory` is preserved for the deploy
-path; only the ownership guard migrates.
+The orchestrator's `__init__` requires `cleanup_policy: ProviderCleanupPolicy`
+and `runner_factory: RunnerFactory`. The `runner_factory` is preserved for
+the deploy path; only the ownership guard migrates.
 
 ## CLI wiring
 
 The CLI is the one place that builds the canonical config and the
-runner factory. It threads the same config into the policy
-constructor.
+runner factory. It threads the same config into the policy factory.
 
 ```python
 # src/vastai_gpu_runner/cli.py (new "batch" subcommand)
@@ -578,89 +749,139 @@ def batch(
     budget: Annotated[float, typer.Option("--budget")] = 0.0,
 ) -> None:
     """Run a batch of cloud GPU units under the user's project image."""
+    from dataclasses import replace
     from vastai_gpu_runner.providers.vastai import (
         VastaiProviderConfig,
         VastaiRunner,
-    )
-    from vastai_gpu_runner.cleanup_policy import (
-        ProviderCleanupPolicy,
+        build_vastai_cleanup_policy,
     )
 
-    # Step 1: one canonical config. Frozen — immutable.
-    config = VastaiProviderConfig.from_env().__class__(
-        allowed_images=image,
+    # Step 1: one canonical config, frozen, immutable.
+    # `from_env` returns the base (credentials loaded, defaults
+    # applied); `replace` overlays the project-specific values.
+    base = VastaiProviderConfig.from_env()
+    config = replace(
+        base,
+        docker_image=image,
+        ownership=OwnershipPolicy(owned_images=frozenset({image})),
     )
 
     # Step 2: runner factory reads from the same config.
     runner_factory = lambda: VastaiRunner.from_config(config)  # noqa: E731
 
     # Step 3: cleanup policy reads from the same config.
-    cleanup_policy = ProviderCleanupPolicy.from_vastai_config(config)
+    cleanup_policy = build_vastai_cleanup_policy(config)
 
     orch = MyOrchestrator(
         runner_factory=runner_factory,
         cleanup_policy=cleanup_policy,
         label_prefix=label,
-        # ... other params ...
     )
     orch.run()
 ```
 
-## Why Option B (canonical config) over Option A (per-runner `destroy_zombie`)
-
-The issue text pivoted to Option B as primary because Option A has
-a fundamental problem: a zombie candidate is **by definition** not
-in the live-runner map, so the orchestrator cannot "use the runner
-from the tuple" — there is no runner for an orphan. The orphan is
-discovered via the provider's list endpoint and the orchestrator
-never had a `CloudRunner` for it. Option A would need to either
-(a) resurrect the runner from the candidate (which requires the
-candidate to carry the deployment config — a heavier wire), or
-(b) run a factory per zombie (which is the bug the v3 5th-pass
-review flagged).
-
-Option B avoids both: the policy is the unit of work, the runner
-factory is a deployment-time construction, and the two never
-compete for the same role.
-
 ## Migration checklist
 
-Seven steps. Each step is independently mergeable behind a
-feature flag, but the migration should land as one PR because the
-intermediate states are not stable (e.g. the orchestrator with no
-`cleanup_policy` is a regression). The PR is the v4 implementation.
+Seven steps. The order is the ChatGPT 5th-pass recommendation
+(canonical types first, adapter before orchestrator, audit before
+deletion). Each step is independently testable but the rollout
+lands as one PR because the intermediate states are not stable.
 
-1. **Add `cleanup_policy.py` with `ProviderCleanupPolicy`, `InstanceCandidate`, `CleanupRefusal`, `CleanupResult`.** Includes the `from_vastai_config` constructor and the `is_candidate` / `destroy` methods. Unit tests for the policy itself (mock `destroy_fn`).
-2. **Add `VastaiProviderConfig` and `VastaiRunner.from_config` to `providers/vastai.py`.** Preserves the existing `VastaiRunner.__init__` constructor as a back-compat path. The new classmethod is the canonical entry point.
-3. **Add `list_vastai_instances()` to `providers/vastai.py`.** Returns `list[InstanceCandidate]`. Existing v3 styles for the JSON shape (parse `id`, `image_uuid`, `label`, `actual_status`, `start_date`).
-4. **Replace `BatchOrchestrator._sweep_zombies` with the policy-driven version.** The orchestrator imports `cleanup_policy.ProviderCleanupPolicy` and the new `list_vastai_instances` (when `provider == VASTAI`). The orchestrator's `__init__` drops the v2 shape and accepts `cleanup_policy`.
-5. **Update `cli.py` to build the canonical config and thread it into both the runner factory and the cleanup policy.** The CLI is the only place that constructs the policy at boot time.
-6. **Delete `orchestrator.py:sweep_zombie_instances`** (already deferred to v3's scope; v4 re-confirms the deletion). The v3 implementation already routed destroy through the v3 protocol; v4's policy-driven sweep removes the last direct caller.
-7. **Update `tests/test_orchestrator.py` and `tests/test_batch.py`** to mock `cleanup_policy.is_candidate` / `cleanup_policy.destroy` instead of `sweep_zombie_instances`. New `tests/test_cleanup_policy.py` for the policy unit tests.
+1. **Add canonical credential + ownership-policy types + invariants + contract tests.**
+   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)`).
+   - `providers/destroy_adapters/vastai.py:CredentialResolution` + `CredentialResolutionResult` (v3 prerequisite — may already exist if v3 is implemented).
+   - Property tests: `OwnershipPolicy.matches` is reflexive (the owned image matches itself); tag-insensitive (`:1.0` and `:latest` match when the repository is owned); `None` opts out (every image matches); empty set rejects everything (fail-closed); different registry prefixes do not match (`registry:5000/myorg/app` ≠ `registry-malicious/myorg/app`).
+   - `CredentialResolution` invariants: `AVAILABLE` requires non-empty pre-stripped key; `ABSENT` and `EXPLICITLY_DISABLED` require empty key.
+
+2. **Add `VastaiProviderConfig` + `VastaiRunner.from_config` + constructor parity.**
+   - `providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership` + `credentials` + `docker_image`).
+   - `__post_init__` invariant: `docker_image ∈ ownership.owned_images` unless ownership is disabled.
+   - `VastaiRunner.from_config(config)` classmethod. Constructor parity test: `VastaiRunner(allowed_images=frozenset({img}), docker_image=img, ...)` and `VastaiRunner.from_config(VastaiProviderConfig(docker_image=img, ownership=OwnershipPolicy(owned_images=frozenset({img})), ...))` produce equivalent attribute values for the runner.
+   - `VastaiProviderConfig.from_env()` reads the v3 `read_vastai_api_key` into `credentials`.
+
+3. **Add Vast.ai cleanup adapter (enumeration + authoritative destroy + CLI fallback).**
+   - `providers/vastai.py:list_vastai_instances()` (returns `list[InstanceCandidate]`, empty list on API failure).
+   - `providers/vastai.py:build_vastai_cleanup_policy(config)` (wires `list_instances_fn` + `destroy_fn` from the v3 adapter).
+   - Adapter tests:
+     - `EXPLICITLY_DISABLED` path: `destroy_fn` returns `refusal=CREDENTIALS_DISABLED` without invoking `vastai_cmd` (mock and assert).
+     - `AVAILABLE` path: `destroy_fn` calls `destroy_vastai_instance` with the loaded key; `verdict=DESTROYED` → `CleanupResult(destroyed=True)`.
+     - `ABSENT` path: `destroy_fn` falls through to CLI fallback (per v3 contract); `verdict=DESTROYED` → `CleanupResult(destroyed=True)`.
+     - `refusal=OWNERSHIP` translation → `CleanupResult(refusal=UNOWNED)`.
+     - `refusal=NO_CREDENTIALS` translation → `CleanupResult(refusal=NO_CREDENTIALS)`.
+     - `list_vastai_instances()` returns `[]` on `RuntimeError` and `JSONDecodeError` (does not raise).
+
+4. **Add orchestrator support behind a fail-closed compatibility path.**
+   - `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required).
+   - `_sweep_zombies` becomes policy-driven (the v4.2 code shape above).
+   - Orchestrator tests:
+     - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once.
+     - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate.
+     - `_sweep_zombies` counts only `destroyed=True` outcomes.
+     - `_sweep_zombies` logs refusals (no exception, no crash).
+     - `_sweep_zombies` continues on `destroy_fn` exceptions.
+     - `_sweep_zombies` does NOT branch on `Provider` (verified by mock introspection: swapping the policy for a RunPod-shaped policy would still work).
+
+5. **Update every composition root, subclass, and existing CLI command.**
+   - `cli.py:cli` (composition root): build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy`.
+   - `cli.py:cleanup` (existing CLI command): migrate to use `build_vastai_cleanup_policy` + `policy.destroy`. No more direct `vastai_cmd(["show", "instances", "--raw"])` parsing.
+   - `cli.py:instances` (existing CLI command): migrate to use `list_vastai_instances()` for the table. The `--allowed-images` flag becomes `--owned-images` (CLI help text updated to point at `OwnershipPolicy`).
+   - `BatchOrchestrator` subclasses (consumer code): existing `BatchOrchestrator(...)` calls now require `cleanup_policy`. Update each subclass's composition.
+   - Test fixtures and conftest: `VastaiProviderConfig` factory fixture for tests.
+
+6. **Add integration tests.**
+   - `tests/integration/test_cleanup_policy_integration.py` (or equivalent):
+     - **disabled-before-enumeration**: config with `credentials=EXPLICITLY_DISABLED`; `policy.destroy(candidate)` returns `CREDENTIALS_DISABLED` even when the candidate's image is owned. `list_instances()` is called but `destroy_fn` is not (no API key passed).
+     - **absent-credential CLI fallback**: config with `credentials=ABSENT`; `policy.destroy(candidate)` falls through to CLI fallback path and the v3 `destroy_vastai_instance` is invoked with `api_key=None` (CLI path).
+     - **empty ownership set**: config with `ownership=OwnershipPolicy(owned_images=frozenset())`; `policy.destroy(candidate)` returns `UNOWNED` for every candidate (fail-closed).
+     - **provider mismatch**: candidate with `provider=Provider.RUNPOD` is passed to a `Provider.VASTAI` policy; returns `UNOWNED` with `provider mismatch` error.
+     - **enumeration failure**: `list_vastai_instances()` raises on `RuntimeError`; `policy.list_instances()` returns `[]` (the policy catches the exception).
+   - The integration tests use mocks; the CLI fallback path is tested with the v3 mock infrastructure.
+
+7. **Delete legacy sweep + duplicated helpers after a repository-wide caller audit.**
+   - `audit_caller_sites.sh` (run before the deletion): grep for any external caller of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use). Update external callers.
+   - Delete `orchestrator.sweep_zombie_instances` (already deferred to v3; v4.2 reaffirms).
+   - Delete `orchestrator.load_vastai_api_key` (v3 deferral reaffirmed).
+   - Delete direct `vastai_cmd(["show", "instances", "--raw"])` parsing in `cli.py:cleanup` and `cli.py:instances`.
+   - Update `tests/test_orchestrator.py` and `tests/test_batch.py` to mock `cleanup_policy.list_instances` and `cleanup_policy.destroy` instead of `sweep_zombie_instances`.
 
 ## Test plan
 
-- `tests/test_cleanup_policy.py` — unit tests for the policy:
-  - `is_candidate` returns True when `repository_image` is None
-  - `is_candidate` returns True when `image_uuid == repository_image`
-  - `is_candidate` returns False when `image_uuid != repository_image`
-  - `is_candidate` is False when `candidate_filter` returns False
-  - `destroy` returns `CleanupResult(destroyed=1)` on protocol success
-  - `destroy` returns `CleanupResult(refusal=UNOWNED)` when ownership check fails
-  - `destroy` returns `CleanupResult(refusal=CREDENTIALS_DISABLED)` when `api_key == ""`
-  - `destroy` returns `CleanupResult(destroyed=0, error=...)` when `destroy_fn` raises
-  - `destroy` returns `CleanupResult(refusal=UNOWNED, error="hostile: ...")` when hostile check fires
-  - `from_vastai_config` wires the Vast.ai adapter correctly
-  - Property-based: `is_candidate` is idempotent (calling it twice returns the same value)
-- `tests/test_providers_vastai.py` — additions for the canonical config:
+- `tests/test_cleanup_policy.py` — unit tests:
+  - `OwnershipPolicy.matches`:
+    - `None` ownership: every image matches (including the empty string)
+    - Non-empty set: exact reference matches
+    - Non-empty set: tag-insensitive repository matches (`:1.0` and `:latest` both match)
+    - Non-empty set: different registry prefix does NOT match
+    - Empty set: no image matches (fail-closed)
+    - Image `myorg/app:1.0` does NOT match `myorg/app-malicious:latest`
+    - `registry:5000/myorg/app:1.0` does NOT match `registry-malicious/myorg/app:1.0`
+  - `ProviderCleanupPolicy.list_instances`:
+    - Returns the wired list
+    - Catches and returns `[]` on `list_instances_fn` exception
+  - `ProviderCleanupPolicy.destroy`:
+    - Provider mismatch returns `UNOWNED` with `provider mismatch` error
+    - Catches `destroy_fn` exceptions and returns `CleanupResult(error=...)`
+    - Delegates to `destroy_fn` on the happy path
+  - `CleanupResult` invariants:
+    - `destroyed=True` + `refusal=...` raises `ValueError`
+    - `destroyed=False` + `refusal=None` + `error=""` raises `ValueError`
+  - `VastaiProviderConfig` invariants:
+    - `docker_image` not in `owned_images` raises `ValueError`
+    - `docker_image` in `owned_images` is valid
+    - `ownership.owned_images is None` (disabled) accepts any `docker_image`
+- `tests/test_providers_vastai.py` — adapter tests:
   - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig`
-  - `list_vastai_instances` returns `InstanceCandidate` records
+  - `list_vastai_instances` returns `list[InstanceCandidate]`
   - `list_vastai_instances` returns `[]` on API error (does not raise)
-- `tests/test_batch.py` — additions for the policy-driven sweep:
-  - `_sweep_zombies` calls `cleanup_policy.is_candidate` and `cleanup_policy.destroy`
-  - `_sweep_zombies` counts only `destroyed == 1` outcomes
-  - `_sweep_zombies` logs refusals
+  - `build_vastai_cleanup_policy` wires the v3 adapter correctly
+- `tests/test_batch.py` — orchestrator wiring:
+  - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once
+  - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate
+  - `_sweep_zombies` counts only `destroyed=True` outcomes
+  - `_sweep_zombies` logs refusals (no exception, no crash)
   - `_sweep_zombies` continues on `destroy_fn` exceptions
+  - `_sweep_zombies` does NOT import provider modules (verified by `inspect.getsource` — should not show `from vastai_gpu_runner.providers.vastai import` in `batch.py`)
+- `tests/integration/test_cleanup_policy_integration.py` — integration tests (six scenarios from step 6 above).
 - Existing tests for `verify_instance_ownership` and `VastaiRunner.destroy_instance` are unchanged (the runner's ownership guard is preserved; only the policy owner changes).
 
 ## Backwards compatibility
@@ -669,59 +890,120 @@ The `VastaiRunner.__init__(allowed_images=..., docker_image=..., ...)`
 constructor is preserved. Existing callers (scripts, unit tests,
 third-party consumers) that build the runner by hand keep working.
 The CLI's new `batch` subcommand is the recommended path; the old
-programmatic path (`MyOrchestrator(runner_factory=...)`) is preserved
-when `cleanup_policy` is supplied alongside the factory.
+programmatic path requires a `cleanup_policy` to be supplied.
 
 The `orchestrator.py:sweep_zombie_instances` function is deleted in
-v4 step 6. The v3 implementation already migrated its callers
+v4 step 7. The v3 implementation already migrated its callers
 through the destroy protocol; v4's policy-driven sweep removes the
 last direct caller. Any external code that imported
 `sweep_zombie_instances` directly must be updated to construct a
-`ProviderCleanupPolicy` and call `policy.destroy(candidate)` per
-enumerated orphan.
+`ProviderCleanupPolicy` and call `policy.destroy(candidate)`.
+
+The `cli.py:cleanup` and `cli.py:instances` commands are refactored
+in v4 step 5. The `--allowed-images` flag is renamed to
+`--owned-images` (with a deprecation cycle: the old flag is
+accepted for one minor version and emits a warning).
 
 ## Out of scope
 
-- **RunPod adapter implementation.** The `from_runpod_config`
-  constructor raises `NotImplementedError` until the RunPod ship
-  PR. The shape is defined here so the orchestrator wiring is
+- **RunPod adapter.** The `ProviderCleanupPolicy` interface is
+  provider-agnostic, but the `build_runpod_cleanup_policy` factory
+  is omitted from this doc — it lands with the RunPod adapter
+  (roadmap item 2). The factory shape is defined by the
+  `ProviderCleanupPolicy` interface; the orchestrator's wiring is
   provider-agnostic from day one.
-- **Dispute webhook.** The `dispute_webhook` field is in the
-  optional future-proofing comments but not on the dataclass
-  (YAGNI). It lands when the dispute workflow is built.
+- **Hostile detection.** The v4 first draft had a `hostile_check`
+  boolean + threshold; the 5th-pass review flagged it as
+  semantically redundant (unowned candidates are refused
+  regardless of age). Hostile detection is deferred to a separate
+  audit stage that emits `AGED_UNOWNED` alerts without changing
+  the destroy decision. When the dispute workflow lands, the
+  hostile stage is added to the policy as a no-side-effect
+  classifier.
+- **Dispute webhook.** The dispute workflow is future work.
+  YAGNI for now.
 - **Bulk-destroy optimisation.** The v4 sweep destroys one
   candidate at a time. A bulk path is a future optimisation
   (YAGNI for now; the per-candidate API call is the safe
   default).
-- **Cross-provider zombie sweep.** If a user runs both Vast.ai
-  and RunPod in the same batch, the v4 design supports one
-  `cleanup_policy` per orchestrator. A multi-policy orchestrator
-  is a future design (the v4 on-by-one design is simpler and
-  covers the current use case).
+- **Cross-provider zombie sweep.** A single orchestrator
+  currently supports one `cleanup_policy`. A multi-policy
+  orchestrator is a future design (the v4 on-by-one design is
+  simpler and covers the current use case).
 
 ## Review process
 
-This design is the v4 follow-up to the v3 architecture. The first
-review prompt for ChatGPT-with-GitHub-plugin will be:
+This is the second review pass on the v4 architecture. The first
+draft was reviewed by ChatGPT and returned 5 BLOCKERs and 7
+CONCERNs; this draft addresses all of them. The diff to the first
+draft is summarized in the "What changes vs the v4 first draft"
+section above.
 
-> Review the v4 architecture design at `docs/architecture-v4-cleanup-policy.md`
-> against the v3 design at `docs/architecture-v3.md` and the
-> current code at `src/vastai_gpu_runner/{batch,orchestrator,runner,cli}.py`
-> and `src/vastai_gpu_runner/providers/vastai.py`. The v4 design
-> resolves issue #19 (the ProviderCleanupPolicy follow-up). Focus
-> on: (1) the canonical-config pattern — does it actually prevent
-> the drift the v3 5th-pass review flagged? (2) the
-> `is_candidate` / `destroy` split — is the second method
-> redundant? (3) the
-> `cleanup_policy.py:ProviderCleanupPolicy` shape — is the frozen
-> dataclass + `destroy_fn` callback idiomatic, or should the
-> policy be split into a `CandidateFilter` + a `DestroyDispatcher`?
-> (4) the RunPod forward path — is `from_runpod_config` raising
-> `NotImplementedError` the right stub, or does it leak an
-> unimplemented state into the orchestrator's code path? (5) the
-> hostile-check semantics — is the threshold-based check the right
-> shape, or should hostile be a separate stage independent of
-> ownership?
+The second review prompt for ChatGPT-with-GitHub-plugin:
+
+> Review the v4 architecture design at PR #22 (file:
+> docs/architecture-v4-cleanup-policy.md) against the v3 design at
+> docs/architecture-v3.md and the current code at
+> src/vastai_gpu_runner/{batch,orchestrator,runner,cli}.py and
+> src/vastai_gpu_runner/providers/vastai.py. The v4 design
+> resolves issue #19 (the ProviderCleanupPolicy follow-up).
+>
+> The first draft was rejected with 5 BLOCKERs and 7 CONCERNs.
+> Verify each finding is addressed:
+>
+> 1. **BLOCKER 1 (dataclass field ordering)**: confirm
+>    `ProviderCleanupPolicy` uses `@dataclass(frozen=True,
+>    kw_only=True)` and all callbacks are keyword-only.
+> 2. **BLOCKER 2 (list_instances on the policy)**: confirm
+>    `list_instances_fn` is added and `list_instances()` is a
+>    public method.
+> 3. **BLOCKER 3 (is_candidate/destroy inconsistency)**: confirm
+>    `destroy()` is authoritative and `is_candidate` was removed
+>    from the orchestrator's call path.
+> 4. **BLOCKER 4 (hostile check)**: confirm the hostile check is
+>    removed from the policy.
+> 5. **BLOCKER 5 (credential model)**: confirm
+>    `CredentialResolution` (three-state) is used in
+>    `VastaiProviderConfig` and `EXPLICITLY_DISABLED` short-
+>    circuits before enumeration.
+> 6. **BLOCKER 6 (ownership semantics)**: confirm
+>    `OwnershipPolicy.matches()` is introduced and consumed by
+>    both the runner and the adapter; confirm the
+>    `docker_image ∈ owned_images` invariant.
+> 7. **BLOCKER 7 (CLI discards from_env)**: confirm the CLI
+>    uses `dataclasses.replace` instead of `from_env().__class__(...)`.
+> 8. **CONCERN 8 (provider factories in core)**: confirm the
+>    Vast.ai factory is moved to `providers/vastai.py` and the
+>    core module has no provider imports.
+> 9. **CONCERN 9 (state filter)**: confirm the state filter is
+>    removed; `list_*_instances()` is complete enumeration;
+>    `destroy()` applies eligibility authoritatively.
+> 10. **CONCERN 10 (CleanupResult invariants)**: confirm the
+>     `__post_init__` invariants are added and the v3
+>     `DestroyVerdict` enum is used.
+> 11. **CONCERN 11 (no-op RunPod adapter)**: confirm
+>     `from_runpod_config` is removed.
+> 12. **CONCERN 12 (migration order)**: confirm the 7-step
+>     checklist is reordered (canonical types first, adapter
+>     before orchestrator, audit before deletion) and the
+>     `cli.py:cleanup` and `cli.py:instances` commands are
+>     addressed.
+>
+> Additionally, identify any new BLOCKERs or CONCERNs introduced
+> by the second draft. Focus on:
+> - The `_repository(image_ref)` function: does it correctly
+>   handle edge cases (empty string, sha256 digests, multi-tag
+>   references)?
+> - The `OwnershipPolicy.__post_init__` freezing: is the
+>   `object.__setattr__` pattern correct on a frozen dataclass?
+> - The `ProviderCleanupPolicy.destroy` provider-mismatch check:
+>   is the error message operator-friendly?
+> - The `VastaiProviderConfig.from_env` constructor: does the
+>   `docker_image or DEFAULT_IMAGE` guard correctly handle the
+>   empty-string case?
+> - The migration step 5: does the `--allowed-images` rename to
+>   `--owned-images` introduce a wire-format break that should be
+>   deferred?
 >
 > Return a labeled list of findings. Each finding is one of:
 > BLOCKER (must fix before merge), CONCERN (should fix, but not
@@ -729,8 +1011,3 @@ review prompt for ChatGPT-with-GitHub-plugin will be:
 > exact line range, the issue, and the proposed fix. If the
 > design is acceptable as-is, say "DESIGN ACCEPTED" with a
 > one-line rationale.
-
-The iteration loop is the same as v3: paste the prompt into
-ChatGPT, paste the response back, apply the fixes, push the
-amended commit, repeat until the response is "DESIGN ACCEPTED" or
-all CONCERNs are resolved.

--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -157,11 +157,13 @@ This sixth draft addresses every finding.
 
 ## Module taxonomy
 
-The v4 doc adds one new module (`cleanup_policy.py`) and modifies two
-existing modules (`providers/destroy_adapters/vastai.py` and
-`providers/vastai.py`). The v3 modules (`providers/destroy.py`,
-`unit_lifecycle.py`, `BatchOrchestrator`, `CloudRunner`) are
-referenced unchanged.
+The v4 doc adds one new module (`cleanup_policy.py`) and modifies
+**four** existing modules (`providers/destroy_adapters/vastai.py`,
+`providers/vastai.py`, `batch.py`, `cli.py`) and deletes legacy
+helpers from `orchestrator.py`. The v3 modules
+(`providers/destroy.py`, `unit_lifecycle.py`) and the `CloudRunner`
+ABC are referenced unchanged. `BatchOrchestrator` is **modified**
+(adds `cleanup_policy` parameter, replaces `_sweep_zombies`).
 
 ### Module ownership (clarified)
 
@@ -170,6 +172,9 @@ referenced unchanged.
 | `providers/destroy.py` (v3 prerequisite) | `DestroyVerdict`, `DestroyRefusal`, `DestroyResult`, `VerifyVerdict`, `VerifyResult`, `DestroyPolicy`, callback protocols, `belt_and_suspenders` | None — referenced verbatim |
 | `providers/destroy_adapters/vastai.py` (v3 + v4) | `CredentialState`, `CredentialResolution`, `read_vastai_api_key()` (env-first), `destroy_vastai_instance()` (amended signature) | Env-first credentials; amended adapter signature |
 | `providers/vastai.py` (v4) | `VastaiProviderConfig`, `VastaiRunner`, `vastai_cmd`, `verify_instance_ownership`, `list_vastai_instances()`, `build_vastai_cleanup_policy()`, `_describe_destroy_result`, `VASTAI_TERMINAL_STATES` | Many (see diff) |
+| `batch.py` (v4) | `BatchOrchestrator` (modified) | Adds required `cleanup_policy: ProviderCleanupPolicy` parameter; replaces `_sweep_zombies` (policy-driven); removes `sweep_zombie_instances` import |
+| `cli.py` (v4) | CLI commands | Refactored `batch` / `cleanup` / `instances` commands; `cli.py:instances` "Owned" column uses `OwnershipPolicy.matches()` (v2 substring match removed) |
+| `orchestrator.py` (v4 deletion) | — | Delete `sweep_zombie_instances`, `load_vastai_api_key` |
 | `cleanup_policy.py` (v4) | `OwnershipPolicy`, `InstanceCandidate`, `CleanupVerdict`, `CleanupRefusal`, `CleanupResult`, `ProviderCleanupPolicy` | New module |
 
 The core `cleanup_policy.py` module imports nothing from `providers/`.
@@ -523,7 +528,7 @@ class ProviderCleanupPolicy:
         on every call, then delegates to ``destroy_fn`` which
         applies eligibility / ownership / credential checks.
 
-        Never raises. Three safety guarantees:
+        Never raises. Two safety guarantees:
 
         1. The catch-all uses ``f"{type(exc).__name__}: {exc}"``
            so the error string is always non-empty (preserves
@@ -573,21 +578,39 @@ class ProviderCleanupPolicy:
         return result
 ```
 
-## `providers/destroy_adapters/vastai.py` — v3 + v4 amendments
+## `providers/destroy_adapters/vastai.py` — v4 amendments (patch-style excerpt)
 
-The v3 design's `CredentialState` + `CredentialResolution` types plus
-the amended `destroy_vastai_instance` signature. The adapter
-**imports** the destroy types from `providers/destroy.py` (v3
-prerequisite); it does not redefine them.
+The v4 design adds the `CredentialState` + `CredentialResolution`
+types plus the amended `destroy_vastai_instance` signature. The
+adapter **imports** the destroy types from `providers/destroy.py`
+(v3 prerequisite); it does not redefine them.
+
+The block below is a **patch-style excerpt** showing only the
+v4-amended content. The unchanged v3 imports (the existing REST
+callbacks, `VASTAI_POLICY`, `belt_and_suspenders`, etc.) remain
+in the file. Implementing this block literally does NOT replace
+the v3 adapter — it only adds the new credential types, the
+env-first resolver, and the amended `destroy_vastai_instance`
+signature.
 
 ```python
 # src/vastai_gpu_runner/providers/destroy_adapters/vastai.py
+#
+# --- v3 imports (unchanged) ---
+#
+# from vastai_gpu_runner.providers.destroy import (
+#     VerifyVerdict, VerifyResult, DestroyPolicy,
+#     belt_and_suspenders,
+# )
+# import requests  # for the v3 REST callbacks
+# import logging  # VASTAI_POLICY timing support
+#
+# --- v4 additions ---
+
 from __future__ import annotations
 
 import logging
 import os
-import subprocess
-import time
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -849,6 +872,13 @@ def verify_instance_ownership(
     Uses ``ownership.matches(image_uuid)`` for the ownership check.
     This is the CLI-auth verification used by the v4 factory's
     CLI fallback path (separate auth context from the REST path).
+
+    Returns True when the instance is not in a well-formed
+    response (treated as "already destroyed"). Returns False on
+    API error, malformed response, ownership mismatch, or any
+    unexpected exception. Mirrors ``list_vastai_instances``'s
+    defensive ``isinstance`` checks so direct callers see the
+    declared ``-> bool`` contract upheld.
     """
     if ownership.owned_images is None:
         return True
@@ -862,7 +892,20 @@ def verify_instance_ownership(
             exc,
         )
         return False
+    if not isinstance(instances, list):
+        logger.warning(
+            "Cannot verify ownership of instance %s — response is not a list (got %s)",
+            instance_id,
+            type(instances).__name__,
+        )
+        return False
     for inst in instances:
+        if not isinstance(inst, dict):
+            logger.warning(
+                "Cannot verify ownership — encountered non-object instance record: %r",
+                inst,
+            )
+            continue
         if str(inst.get("id")) == str(instance_id):
             image = str(inst.get("image_uuid", ""))
             if ownership.matches(image):
@@ -1623,6 +1666,7 @@ def instances(
     from rich.console import Console
     from rich.table import Table
     from vastai_gpu_runner.cleanup_policy import OwnershipPolicy
+    from vastai_gpu_runner.providers.vastai import list_vastai_instances
 
     console = Console()
     candidates = list_vastai_instances()
@@ -1743,7 +1787,7 @@ steps then build on v3's `providers/destroy.py` module
      - **CLI --allowed-images None**: opt-out (every image considered owned).
      - **destroy_fn returns None**: orchestrator receives `CleanupResult(verdict=UNKNOWN, error="...invalid result type NoneType")`.
      - **VastaiRunner logs typed result**: LEAKED outcome produces an `ERROR`-level log line with the structured diagnostic context.
-     - **instances command ownership column**: malicious prefix `myorg/app-malicious:latest` shown as `no` when `--allowed-images myorg/app:1.0`; tag-insensitive `myorg/app:latest` shown as `yes`; registry-port `registry:5000/myorg/app:1.0` shown as `no` when `--allowed-images myorg/app`; empty set `--allowed-images ""` shows every instance as `no`.
+     - **instances command ownership column**: malicious prefix `myorg/app-malicious:latest` shown as `no` when `--allowed-images myorg/app:1.0`; tag-insensitive `myorg/app:latest` shown as `yes`; digest `myorg/app@sha256:<digest>` shown as `yes` when `--allowed-images myorg/app:1.0` (tag-insensitive repository match); registry-port `registry:5000/myorg/app:1.0` shown as `no` when `--allowed-images myorg/app`; positive registry-port `registry:5000/myorg/app:1.0` shown as `yes` when `--allowed-images registry:5000/myorg/app:1.0`; empty set `--allowed-images ""` shows every instance as `no`.
 
 7. **Delete legacy sweep + duplicated helpers after a repository-wide caller audit.**
    - `audit_caller_sites.sh` (run before deletion): grep for external callers of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use), `providers.vastai._image_is_allowed`, `cli.instances`'s substring match. Update external callers.

--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -22,47 +22,45 @@ In one paragraph: the ownership-guard policy used by the zombie sweep
 moves from a `VastaiRunner.allowed_images` attribute (which the
 orchestrator can only read by introspecting a runner it has no
 business constructing) to a single, immutable `ProviderCleanupPolicy`
-object that is constructed once at boot time from the same canonical
-provider config used to build the runner factory. The runner factory
-and the cleanup policy now share **one** source of truth for "what
-counts as ours" and "what to do with not-ours" — no per-destroy runner
-construction, no drift between the `destroy_instance` ownership guard
-and the zombie-sweep ownership guard. The shared ownership semantics
-live in an `OwnershipPolicy` frozen dataclass with a single
-`matches(image_ref)` method (exact reference OR tag-insensitive
-repository equality, per the v3 contract), consumed by both the
-runner and the cleanup adapter via the v3 destroy adapter (which now
-accepts `OwnershipPolicy` directly instead of a raw set). The
-credential semantics live in the v3 `CredentialState` enum and
-`CredentialResolution` dataclass (three-state: `AVAILABLE` / `ABSENT` /
-`EXPLICITLY_DISABLED`), passed verbatim into the v3 adapter (no
-internal re-resolution). The `ProviderCleanupPolicy` is frozen
-(`kw_only=True`), provider-agnostic (a dataclass with two methods:
-`list_instances()` and `destroy(candidate)`), and exposes the destroy
-contract as the authoritative gate — the orchestrator passes every
-label-matching, untracked candidate to `destroy()` and records the
-`CleanupResult` (typed `CleanupVerdict` or `CleanupRefusal`). The
-provider-specific adapters live in `providers/vastai.py` (the
-`build_vastai_cleanup_policy` factory); the core `cleanup_policy.py`
-module has **no** provider-specific imports. The Vast.ai factory
-wraps `list_vastai_instances` so the v3 contract's
-`EXPLICITLY_DISABLED` short-circuit is honored *before* enumeration.
+object that is constructed once at boot time from the canonical
+`OwnershipPolicy` + `CredentialResolution` read at boot time. The
+runner and the cleanup policy now share **one** ownership semantic
+(`OwnershipPolicy.matches(image_ref)`) and **one** credential snapshot
+(`CredentialResolution`), consumed verbatim by both — no per-destroy
+runner construction, no semantic drift between the runner's destroy
+guard and the zombie-sweep guard. The `ProviderCleanupPolicy` is
+frozen (`kw_only=True`), provider-agnostic, and exposes
+`list_instances()` + `destroy(candidate)` as the two methods the
+orchestrator calls. The factory (`build_vastai_cleanup_policy`,
+`ownership`, `credentials`) wires the v3 `destroy_vastai_instance`
+adapter for the REST path and intercepts `NO_CREDENTIALS` to run the
+CLI fallback (CLI ownership verification + CLI destroy →
+`CLI_ATTEMPTED` verdict). The factory wraps `list_vastai_instances`
+so `EXPLICITLY_DISABLED` credentials short-circuit before enumeration.
+The orchestrator logs every non-`DESTROYED` outcome at a severity
+matching its operational impact (`LEAKED` = `ERROR`, `UNKNOWN` /
+`CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, refusals =
+`INFO`). The `VastaiRunner.destroy_instance` method delegates entirely
+to the v3 adapter (no v2 regression).
 
 Diff vs v3 once v3 is implemented:
 
-- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, with provider-neutral display fields), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`)
-- **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc., with `docker_image` non-empty + ownership invariant)
-- **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(config)` — provider-owned factory (core module has no provider imports)
-- **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`
+- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, non-empty `instance_id` invariant), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`, declared `_normalised` cache field)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc.)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(*, ownership, credentials)` — provider-owned factory that takes the two canonical objects directly (no config wrapper)
+- **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`, validates `instance_id` non-empty
 - **~** `providers/destroy_adapters/vastai.py:destroy_vastai_instance` accepts `ownership: OwnershipPolicy` directly (replaces `allowed_images: frozenset[str]`); accepts `credentials: CredentialResolution | None` (defaults to `read_vastai_api_key()` for back-compat direct callers). The v3 implementation must adopt this signature.
-- **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (already required; v3 design). The orchestrator calls `policy.list_instances()` and `policy.destroy(candidate)` — it never branches on `Provider`, never imports provider modules.
-- **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and the tracked-id exclusion stay on the orchestrator (per-batch scope). Every other decision (eligibility, ownership, credentials) is delegated to `policy.destroy()`. The orchestrator logs every non-`DESTROYED` outcome (CLI fallbacks, LEAKED, UNKNOWN, refusals).
-- **~** `VastaiRunner.__init__` keeps the `allowed_images` parameter for the direct-construction back-compat path (builds an `OwnershipPolicy` from it). `VastaiRunner.from_config(config)` is the canonical entry point used by the CLI and passes the `OwnershipPolicy` instance directly (no conversion to a set).
-- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new `VastaiProviderConfig` + `ProviderCleanupPolicy` API. The CLI no longer parses Vast.ai JSON directly. The `--allowed-images` flag is preserved as canonical; `--owned-images` is added as a documented alias.
+- **~** `providers/destroy_adapters/vastai.py:CredentialState` is `StrEnum` (matches v3 verbatim — the v4 third draft used plain `Enum`).
+- **~** `VastaiRunner.__init__` accepts `ownership: OwnershipPolicy | None` and `credentials: CredentialResolution | None`; rejects simultaneous `ownership=` and deprecated `allowed_images=` with `ValueError`.
+- **~** `VastaiRunner.from_config(config)` preserves both `canonical.ownership` and `canonical.credentials`.
+- **~** `VastaiRunner.destroy_instance` delegates entirely to `destroy_vastai_instance(...)` — no v2-style inline ownership pre-check, no inline REST stop/delete/verify. Returns `bool` from the typed adapter result.
+- **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required). The orchestrator calls `policy.list_instances()` and `policy.destroy(candidate)` — never branches on `Provider`, never imports provider modules.
+- **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and tracked-id exclusion stay on the orchestrator. Every other decision is delegated to `policy.destroy()`. The orchestrator logs every non-`DESTROYED` outcome at severity matching operational impact.
+- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new API. The `--allowed-images` flag is the canonical primary; `--owned-images` is an alias.
 - **—** `orchestrator.py:sweep_zombie_instances` (v3 deletion) — reaffirmed. The v4 implementation removes the last direct caller.
-- **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) — reaffirmed. Credential loading lives in `providers/destroy_adapters/vastai.py` (v3).
-- **—** `providers/vastai.py:_image_is_allowed` (raw set check) — replaced by `OwnershipPolicy.matches()`. The semantic drift between runner and adapter is impossible because both call the same method.
-- **~** `tests/test_orchestrator.py` and `tests/test_batch.py` — mock `cleanup_policy.list_instances()` and `cleanup_policy.destroy()` instead of `sweep_zombie_instances`. New `tests/test_cleanup_policy.py` for the policy unit tests.
+- **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) — reaffirmed.
+- **—** `providers/vastai.py:_image_is_allowed` (raw set check) — replaced by `OwnershipPolicy.matches()`.
+- **~** `tests/test_orchestrator.py` and `tests/test_batch.py` — mock `cleanup_policy.list_instances()` and `cleanup_policy.destroy()` instead of `sweep_zombie_instances`.
 
 ## Why Option B (canonical config) over Option A (per-runner `destroy_zombie`)
 
@@ -79,46 +77,67 @@ review flagged).
 
 Option B avoids both: the policy is the unit of work, the runner
 factory is a deployment-time construction, and the two never
-compete for the same role. The canonical config is the single
-source of truth for both the deployment identity and the destruction
-identity.
+compete for the same role. The `OwnershipPolicy` and
+`CredentialResolution` are the two canonical objects shared by the
+runner factory and the cleanup-policy factory. The runner wraps them
+in `VastaiProviderConfig` (because the runner also needs
+`docker_image`, `setup_commands`, etc.); the cleanup-policy factory
+takes them directly.
 
-## What changes vs the v4 first + second drafts (5th + 6th pass reviews)
+## What changes vs the v4 first + second + third drafts (5th + 6th + 7th pass reviews)
 
 The first draft was rejected with 5 BLOCKERs and 7 CONCERNs. The
 second draft was rejected with 7 BLOCKERs, 2 CONCERNs, and 3 NITs.
-This third draft addresses every finding. The substantive changes:
+The third draft was rejected with 6 BLOCKERs, 4 CONCERNs, and 2 NITs.
+This fourth draft addresses every finding.
 
-### Applied from the 5th-pass review
+### Applied from the 7th-pass review (this pass)
 
-- Dataclass field ordering switched to `@dataclass(frozen=True, kw_only=True)` (BLOCKER 1).
-- `list_instances_fn` + `list_instances()` method on the policy (BLOCKER 2).
-- `destroy()` is authoritative; `is_candidate` was removed from the orchestrator's call path (BLOCKER 3).
-- Hostile check removed (BLOCKER 4).
-- v3 `CredentialResolution` + `CredentialResolutionResult` used (now corrected — see 6th-pass BLOCKER 3 below).
-- `OwnershipPolicy.matches()` introduced (now corrected — see 6th-pass BLOCKER 1 below).
-- CLI uses `dataclasses.replace` (BLOCKER 7).
-- Provider factories moved to `providers/vastai.py` (CONCERN 8).
-- State filter removed; complete enumeration + authoritative eligibility (now corrected — see 6th-pass CONCERN 9 below).
-- `CleanupResult` invariants added (now tightened — see 6th-pass CONCERN 8 below).
-- `from_runpod_config` removed (CONCERN 11).
-- Migration order revised (CONCERN 12).
+- **ABSENT-credential CLI fallback implemented** in the factory. The factory intercepts `DestroyRefusal.NO_CREDENTIALS` and runs the CLI fallback path: `verify_instance_ownership` (CLI auth context) → if not owned return `OWNERSHIP`, else `vastai_cmd(["destroy", "instance", ...])` → `CLI_ATTEMPTED` (destruction unconfirmed) on command success or `UNKNOWN` on command failure. The canonical ABSENT resolution is passed to the REST adapter (not `None`). (BLOCKER 1)
+- **v3 `DestroyResult` translation corrected.** v3 `DestroyVerdict` has exactly `DESTROYED | LEAKED | UNKNOWN` (no `CLI_ATTEMPTED` — that's only in v4 `CleanupVerdict`). v3 `DestroyResult` has `attempts`, `stop_error`, `last_status_code`, `verify_error` — no generic `error` field. Diagnostic text is built from the structured fields via a `_describe(result)` helper. (BLOCKER 2)
+- **`VastaiRunner.destroy_instance` delegates to v3 adapter.** No v2-style inline ownership pre-check, no inline REST stop/delete/verify. The runner adds `credentials` to its constructor, `from_config` preserves the canonical `CredentialResolution`, and `destroy_instance` is a single adapter call. Simultaneous `ownership=` and `allowed_images=` raises `ValueError`. (BLOCKER 3)
+- **`never raises` catch path hardened.** The catch returns `error=f"{type(exc).__name__}: {exc}"` so `error` is always non-empty even for `RuntimeError()` with no message. The `CleanupResult.__post_init__` invariant is preserved. (BLOCKER 4)
+- **`build_vastai_cleanup_policy` takes `ownership` + `credentials` directly.** No `VastaiProviderConfig` wrapper — the deployment-image invariant in `VastaiProviderConfig.__post_init__` does not apply to listing/cleanup-only commands. The batch command extracts `ownership` and `credentials` from `VastaiProviderConfig`; the cleanup command constructs them directly from CLI args. (BLOCKER 5)
+- **`instance_id` non-empty validated at two boundaries.** `list_vastai_instances` skips records with empty `instance_id`; `InstanceCandidate.__post_init__` raises `ValueError` for empty or whitespace-only IDs. (BLOCKER 6)
+- **`_normalised` declared as a dataclass field** with `field(init=False, repr=False, compare=False)`. The `object.__setattr__` pattern in `__post_init__` is retained. (CONCERN 7)
+- **`CredentialState` uses `StrEnum`** matching v3 verbatim. (CONCERN 8)
+- **`VASTAI_TERMINAL_STATES` (negative list)** replaces the previous positive allowlist. Only `destroyed` is skipped; new Vast.ai states are processed. (CONCERN 9)
+- **Logging severity by outcome.** `LEAKED` = `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, refusals = `INFO`. Each log line includes the instance ID. (CONCERN 10)
+- **`--allowed-images` is the canonical CLI flag** (declared first in `typer.Option`); `--owned-images` is the alias. The Python parameter is `allowed_images`. (NIT 11)
+- **Historical `is_candidate` reference removed** from the prose (the historical change summary no longer mentions it; the active flow is what matters). (NIT 12)
 
-### Applied from the 6th-pass review (this pass)
+### Applied from the 6th-pass review (third pass)
 
-- **`_repository(image_ref)` fixed** to match v3 contract: strips digest, strips only the final tag separator (after the last `/`), preserves registry and port, normalises both candidate and owned entries. The previous implementation returned the digest reference unchanged and didn't normalise the owned set. (BLOCKER 1)
-- **Runner and adapter consume `OwnershipPolicy.matches()` directly.** The runner's `__init__` keeps the `allowed_images` parameter as a deprecated back-compat alias (it builds an `OwnershipPolicy` from it); `from_config` passes the `OwnershipPolicy` instance unchanged. The v3 `destroy_vastai_instance` adapter is updated to accept `ownership: OwnershipPolicy` (replacing `allowed_images: frozenset[str]`); both the runner and the cleanup factory call `ownership.matches(image_uuid)`. (BLOCKER 2)
-- **v3 type names used exactly.** The v3 design has `CredentialState` (enum) + `CredentialResolution` (dataclass with `state` and `key` fields, `ValueError` invariants). The v4 second draft misnamed these. (BLOCKER 3)
-- **`EXPLICITLY_DISABLED` short-circuits before enumeration.** The Vast.ai factory wraps `list_vastai_instances` so that an explicit-empty credential skips the CLI enumeration step entirely (the v3 contract). The factory wires the wrapped function into `list_instances_fn`, not the raw helper. The integration test asserts that `vastai_cmd` is not called when credentials are disabled. (BLOCKER 4)
-- **CLI fallback and DestroyResult translation corrected.** The `_destroy` callback now (a) refuses `EXPLICITLY_DISABLED` without provider calls, (b) uses the canonical API key for the REST path, (c) runs the v3 CLI fallback for `ABSENT`, (d) returns `CLI_ATTEMPTED` (not `DESTROYED`) after a successful CLI command, (e) translates all four v3 verdicts (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`) and all three v3 refusals (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED`). `CleanupResult` uses `verdict: CleanupVerdict | None` and `refusal: CleanupRefusal | None` (mutually exclusive), not a boolean. The orchestrator logs every non-`DESTROYED` outcome. (BLOCKER 5)
-- **`docker_image` non-empty enforced.** `VastaiProviderConfig.__post_init__` rejects empty or whitespace-only `docker_image`. `from_env()` uses `DEFAULT_IMAGE if docker_image is None else docker_image` — explicit empty string is a `ValueError`. (BLOCKER 6)
-- **Undefined names removed.** `cleanup_policy.py` adds `import logging; logger = logging.getLogger(__name__)`. `cli.py` adds `from vastai_gpu_runner.cleanup_policy import OwnershipPolicy`. Unused `_TAG_RE`, `Iterable`, `DestroyResult` (TYPE_CHECKING), and `VASTAI_POLICY` imports are removed. (BLOCKER 7)
-- **`CleanupResult` invariants tightened.** Now uses `verdict | refusal` (mutually exclusive) instead of `destroyed: bool`. `DESTROYED` requires empty `error`; every other outcome requires non-empty `error`. (CONCERN 8)
-- **Authoritative eligibility implemented.** The factory's `_destroy` checks the candidate's state against an explicit `ELIGIBLE_STATES` set (defined as a module constant in `providers/vastai.py`) and returns `INELIGIBLE_STATE` on failure. The orchestrator passes every candidate to `destroy()`; the factory decides. (CONCERN 9)
-- **`InstanceCandidate` enriched for CLI display.** Adds `gpu_model: str = ""`, `cost_per_hour: float = 0.0`, `ownership_key: str = ""` (provider-neutral) alongside the existing `image_uuid: str = ""` (Vast.ai-specific). The Vast.ai factory fills both `image_uuid` and `ownership_key` (same value). Future RunPod factory will fill `ownership_key` only. (CONCERN 10)
-- **CLI flag renamed carefully.** `--allowed-images` is preserved as canonical; `--owned-images` is added as a documented alias. The rename is deferred to a separate CLI compatibility change. (CONCERN 11)
-- **`provider=Provider.VASTAI` simplified** (NIT 12) and provider-mismatch diagnostic improved (NIT 13).
-- **Stale prose cleaned up.** All references to `is_candidate`, "hostile classification", "verbidden", and "the core module has provider-specific imports" are corrected. (NIT 14)
+- `_repository(image_ref)` strips digest, strips only the final tag separator (after the last `/`), preserves registry and port, rejects malformed references.
+- Runner and adapter consume `OwnershipPolicy.matches()` directly.
+- v3 type names used exactly (`CredentialState`, `CredentialResolution`).
+- `EXPLICITLY_DISABLED` short-circuits before enumeration.
+- CLI fallback + `DestroyResult` translation (superseded by 7th-pass BLOCKER 1 above).
+- `docker_image` non-empty + pre-stripped invariant.
+- Undefined names fixed (logger import, OwnershipPolicy imports).
+- `CleanupResult` invariants tightened.
+- Authoritative eligibility implemented (now superseded by 7th-pass CONCERN 9 negative-list).
+- `InstanceCandidate` enriched with `gpu_model`, `cost_per_hour`, `ownership_key`.
+- CLI flag kept as `--allowed-images` canonical.
+
+### Applied from the 5th-pass review (second pass)
+
+- `@dataclass(frozen=True, kw_only=True)` for `ProviderCleanupPolicy`.
+- `list_instances_fn` + `list_instances()` method on the policy.
+- `destroy()` is authoritative.
+- Hostile check removed.
+- v3 `CredentialResolution` types used.
+- `OwnershipPolicy.matches()` introduced.
+- CLI uses `dataclasses.replace`.
+- Provider factories moved to `providers/vastai.py`.
+- State filter removed (now superseded by 7th-pass CONCERN 9 negative-list).
+- `CleanupResult` invariants added.
+- `from_runpod_config` removed.
+- Migration order revised.
+
+### Applied from the 5th-pass review (first draft)
+
+- The first draft had BLOCKERs 1-5 and CONCERNs 1-7; all addressed in subsequent passes.
 
 ## Module taxonomy
 
@@ -143,24 +162,24 @@ core module imports nothing from `providers/`.
 
 ### New: `providers/vastai.py:build_vastai_cleanup_policy` — Vast.ai factory
 
-The Vast.ai factory is a provider-owned function. It reads the
-canonical `VastaiProviderConfig`, wires the v3 `destroy_vastai_instance`
-+ a wrapped `list_vastai_instances` into the policy, and returns the
-configured `ProviderCleanupPolicy`. The factory is the single point
-of contact between the Vast.ai adapter and the generic policy.
+The Vast.ai factory is a provider-owned function. It takes the two
+canonical objects (`OwnershipPolicy`, `CredentialResolution`)
+directly, wires the v3 `destroy_vastai_instance` + a wrapped
+`list_vastai_instances` into the policy, and returns the configured
+`ProviderCleanupPolicy`. The factory intercepts `NO_CREDENTIALS` for
+the CLI fallback path.
 
 The RunPod factory is omitted from this doc — it lands with the
-RunPod adapter (roadmap item 2). The shape is defined by the
-`ProviderCleanupPolicy` interface; the orchestrator's wiring is
-provider-agnostic from day one.
+RunPod adapter (roadmap item 2).
 
 ## Layered design (v4)
 
 ```
 ┌─────────────────────────────────────────────────┐
 │  CLI (cli.py)                                   │  User-facing commands
-│    └── builds VastaiProviderConfig once,        │
-│        threads it into both runner factory      │
+│    └── builds OwnershipPolicy +                 │
+│        CredentialResolution once, threads       │
+│        both into VastaiRunner.from_config       │
 │        and build_vastai_cleanup_policy          │
 ├─────────────────────────────────────────────────┤
 │  BatchOrchestrator (batch.py)                   │  Phase loop + side-effect dispatchers
@@ -194,12 +213,10 @@ provider-agnostic from day one.
 └──────────────┴──────────────┴───────────────────┘
 ```
 
-## `OwnershipPolicy` shape
+## `cleanup_policy.py` — full module
 
-Single frozen dataclass, owned by `cleanup_policy.py`. The v3
-ownership semantics (exact reference OR tag-insensitive repository
-equality, preserving registry and port) live here, in one method,
-consumed by both the runner and the cleanup adapter.
+All shapes that live in `cleanup_policy.py` are shown together so
+imports and references resolve within one block.
 
 ```python
 # src/vastai_gpu_runner/cleanup_policy.py
@@ -208,13 +225,18 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import AbstractSet, Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vastai_gpu_runner.types import Provider
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# _repository helper — tag-insensitive image reference normalisation
+# ---------------------------------------------------------------------------
 
 
 def _repository(ref: str) -> str:
@@ -248,6 +270,11 @@ def _repository(ref: str) -> str:
     return without_digest
 
 
+# ---------------------------------------------------------------------------
+# OwnershipPolicy
+# ---------------------------------------------------------------------------
+
+
 @dataclass(frozen=True)
 class OwnershipPolicy:
     """Shared ownership semantics — runner and cleanup adapter both call this.
@@ -264,17 +291,18 @@ class OwnershipPolicy:
             check (every image is considered owned). An empty set
             is distinct from ``None`` — it means the project owns
             no images and every ownership check fails (fail-closed).
-
-    Invariants:
-        - ``owned_images`` is preserved as a frozenset (caller
-          mutation is impossible).
-        - ``None`` and ``frozenset()`` are distinct: ``None`` opts
-          out, ``frozenset()`` opts in but rejects everything.
-        - The normalised owned repositories are precomputed and
-          cached so ``matches()`` is O(1) per call.
+        _normalised: Internal cache of normalised repositories.
+            Precomputed in ``__post_init__`` so ``matches()`` is O(1).
+            Excluded from equality, hashing, and repr.
     """
 
     owned_images: AbstractSet[str] | None = None
+    _normalised: frozenset[str] | None = field(
+        init=False,
+        repr=False,
+        compare=False,
+        default=None,
+    )
 
     def __post_init__(self) -> None:
         if self.owned_images is None:
@@ -296,12 +324,6 @@ class OwnershipPolicy:
         the tag-insensitive repository of ``image_ref`` matches
         the tag-insensitive repository of any entry in
         ``owned_images``.
-
-        Examples (assuming ``owned_images={"myorg/app:1.0"}``):
-            >>> matches("myorg/app:1.0")        # True (exact)
-            >>> matches("myorg/app:latest")     # True (repo match)
-            >>> matches("myorg/app-malicious")  # False (different repo)
-            >>> matches("registry:5000/myorg/app:1.0")  # False (different registry)
         """
         if self.owned_images is None:
             return True
@@ -310,19 +332,216 @@ class OwnershipPolicy:
         repo = _repository(image_ref)
         if not repo:
             return False
-        return repo in self._normalised  # type: ignore[operator]
+        return repo in self._normalised
+
+
+# ---------------------------------------------------------------------------
+# Enums: CleanupVerdict, CleanupRefusal
+# ---------------------------------------------------------------------------
+
+
+class CleanupVerdict(Enum):
+    """Outcome verdicts returned by ``policy.destroy``.
+
+    These are protocol outcomes — the destroy protocol ran to
+    completion and reported a verdict. ``DESTROYED`` is the only
+    success; the others are observable non-success states that
+    the orchestrator logs distinctly.
+
+    ``CLI_ATTEMPTED`` is a v4 verdict produced by the factory's
+    CLI fallback path — it is NOT a v3 protocol verdict.
+    """
+
+    DESTROYED = "destroyed"
+    CLI_ATTEMPTED = "cli_attempted"  # CLI fallback ran; destruction not confirmed
+    LEAKED = "leaked"                # Protocol ran but instance was resurrected
+    UNKNOWN = "unknown"              # Protocol did not report a clear outcome
+
+
+class CleanupRefusal(Enum):
+    """Pre-protocol refusal reasons returned by ``policy.destroy``.
+
+    These are policy-level decisions — the destroy protocol is
+    never entered. The orchestrator logs the refusal and skips
+    the candidate.
+    """
+
+    OWNERSHIP = "ownership"               # image/template not owned by this policy
+    NO_CREDENTIALS = "no_credentials"     # no API key configured; CLI fallback attempted
+    CREDENTIALS_DISABLED = "credentials_disabled"  # VASTAI_API_KEY="" — CLI fallback forbidden
+    INELIGIBLE_STATE = "ineligible_state" # candidate.state is terminal (destroyed) or malformed
+    PROVIDER_MISMATCH = "provider_mismatch"  # candidate.provider != policy.provider
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses: InstanceCandidate, CleanupResult
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InstanceCandidate:
+    """Read-only snapshot of one instance returned by ``list_*_instances``.
+
+    Frozen so the policy can hold it without aliasing surprises.
+    Fields are the union of what every provider can feasibly
+    expose; providers that do not have a field (e.g. RunPod has
+    no ``image_uuid``) leave it empty.
+
+    Invariant: ``instance_id`` must be non-empty and pre-stripped.
+    """
+
+    provider: "Provider"
+    instance_id: str
+    label: str
+    state: str
+    image_uuid: str = ""
+    ownership_key: str = ""
+    gpu_model: str = ""
+    cost_per_hour: float = 0.0
+    started_at: float = 0.0
+
+    def __post_init__(self) -> None:
+        if (
+            not self.instance_id
+            or self.instance_id != self.instance_id.strip()
+        ):
+            raise ValueError(
+                "InstanceCandidate.instance_id must be non-empty and pre-stripped"
+            )
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Outcome of ``policy.destroy``.
+
+    Exactly one of ``verdict`` (CleanupVerdict) or ``refusal``
+    (CleanupRefusal) is set — never both, never neither. ``error``
+    is non-empty on every non-DESTROYED outcome (it carries the
+    structured diagnostic context); ``error`` is empty on
+    DESTROYED (success has no error).
+
+    The cleanup policy wraps the v3 ``DestroyResult`` (which has
+    ``verdict: DestroyVerdict`` + ``refusal: DestroyRefusal``)
+    in this tighter shape for the orchestrator.
+    """
+
+    verdict: Optional[CleanupVerdict] = None
+    refusal: Optional[CleanupRefusal] = None
+    error: str = ""
+
+    def __post_init__(self) -> None:
+        if (self.verdict is None) == (self.refusal is None):
+            raise ValueError(
+                "CleanupResult: exactly one of verdict or refusal must be set"
+            )
+        if self.verdict == CleanupVerdict.DESTROYED:
+            if self.error:
+                raise ValueError(
+                    "CleanupResult.DESTROYED must have empty error"
+                )
+        elif not self.error:
+            ident = (
+                self.verdict.value
+                if self.verdict is not None
+                else self.refusal.value
+            )
+            raise ValueError(
+                f"CleanupResult: {ident} must have non-empty error"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ProviderCleanupPolicy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProviderCleanupPolicy:
+    """Per-provider cleanup contract.
+
+    The core module is provider-agnostic: it imports nothing from
+    ``providers/``. The ``list_instances_fn`` and ``destroy_fn``
+    callbacks are wired by the provider-owned factory (e.g.
+    ``build_vastai_cleanup_policy``).
+    """
+
+    provider: "Provider"
+    ownership: OwnershipPolicy
+    list_instances_fn: Callable[[], list[InstanceCandidate]] = field(repr=False)
+    destroy_fn: Callable[[InstanceCandidate], CleanupResult] = field(repr=False)
+
+    def list_instances(self) -> list[InstanceCandidate]:
+        """Read-only enumeration of provider instances."""
+        try:
+            return self.list_instances_fn()
+        except Exception as exc:
+            logger.warning("Cleanup policy: list_instances raised: %s", exc)
+            return []
+
+    def destroy(self, candidate: InstanceCandidate) -> CleanupResult:
+        """Run the per-provider destroy on one candidate.
+
+        Authoritative gate: this method re-validates the
+        candidate's provider identity (PROVIDER_MISMATCH refusal)
+        on every call, then delegates to ``destroy_fn`` which
+        applies eligibility / ownership / credential checks.
+
+        Never raises. The error string in the catch path is
+        always non-empty (uses ``type(exc).__name__`` as a
+        minimum) so the ``CleanupResult`` invariant is preserved.
+        """
+        if candidate.provider != self.provider:
+            return CleanupResult(
+                refusal=CleanupRefusal.PROVIDER_MISMATCH,
+                error=(
+                    f"candidate {candidate.instance_id!r} belongs to "
+                    f"provider {candidate.provider.value!r}; cleanup "
+                    f"policy expects {self.provider.value!r}"
+                ),
+            )
+        try:
+            return self.destroy_fn(candidate)
+        except Exception as exc:
+            logger.warning(
+                "Cleanup: destroy_fn raised for %s: %s",
+                candidate.instance_id,
+                exc,
+            )
+            return CleanupResult(
+                verdict=CleanupVerdict.UNKNOWN,
+                error=f"{type(exc).__name__}: {exc}",
+            )
 ```
 
-## `CredentialState` + `CredentialResolution` shape (v3 shapes, used unchanged)
+## `providers/destroy_adapters/vastai.py` — v3 + v4 additions
 
-The v3 design defines these types in `providers/destroy_adapters/vastai.py`.
-The v4 design uses them unchanged — the names matter because the v3
-adapter (when implemented) and the v4 factory (this design) must
-agree.
+The v3 design's `CredentialState` + `CredentialResolution` types
+plus the amended `destroy_vastai_instance` signature.
 
 ```python
-# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py (v3 shape — verbatim)
-class CredentialState(Enum):
+# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Optional
+
+from vastai_gpu_runner.cleanup_policy import OwnershipPolicy
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Credential types (v3 shape — verbatim)
+# ---------------------------------------------------------------------------
+
+
+class CredentialState(StrEnum):
     """Three-state credential resolution."""
     AVAILABLE = "available"
     ABSENT = "absent"
@@ -336,9 +555,6 @@ class CredentialResolution:
     Invariants (enforced in __post_init__):
         - AVAILABLE requires non-empty, pre-stripped key.
         - ABSENT and EXPLICITLY_DISABLED require empty key.
-
-    Note: pre-stripped means the key has no leading/trailing
-    whitespace. The v3 read_vastai_api_key() strips before checking.
     """
     state: CredentialState
     key: str = ""
@@ -354,25 +570,204 @@ class CredentialResolution:
                 raise ValueError(
                     f"CredentialResolution.{self.state.value} requires empty key"
                 )
+
+
+# ---------------------------------------------------------------------------
+# read_vastai_api_key
+# ---------------------------------------------------------------------------
+
+
+def read_vastai_api_key() -> CredentialResolution:
+    """Read the Vast.ai API key from the standard file paths.
+
+    Returns a frozen CredentialResolution. The resolution distinguishes
+    three states:
+        - EXPLICITLY_DISABLED: the key file exists but is empty
+          (the user has explicitly disabled credentials).
+        - ABSENT: no key file is present.
+        - AVAILABLE: a non-empty key was found.
+    """
+    for kp in (
+        Path("~/.config/vastai/vast_api_key").expanduser(),
+        Path("~/.vast_api_key").expanduser(),
+    ):
+        if kp.exists():
+            raw = kp.read_text()
+            stripped = raw.strip()
+            if not stripped:
+                return CredentialResolution(
+                    state=CredentialState.EXPLICITLY_DISABLED
+                )
+            return CredentialResolution(
+                state=CredentialState.AVAILABLE, key=stripped
+            )
+    return CredentialResolution(state=CredentialState.ABSENT)
+
+
+# ---------------------------------------------------------------------------
+# DestroyResult shape (v3)
+# ---------------------------------------------------------------------------
+
+
+class DestroyVerdict(StrEnum):
+    """Outcome verdicts returned by the v3 belt-and-suspenders protocol.
+
+    Three values. CLI_ATTEMPTED is NOT a v3 verdict — it is a v4
+    CleanupVerdict produced by the factory's CLI fallback.
+    """
+    DESTROYED = "destroyed"
+    LEAKED = "leaked"
+    UNKNOWN = "unknown"
+
+
+class DestroyRefusal(StrEnum):
+    """Pre-protocol refusal reasons returned by destroy_vastai_instance."""
+    OWNERSHIP = "ownership"
+    NO_CREDENTIALS = "no_credentials"
+    CREDENTIALS_DISABLED = "credentials_disabled"
+
+
+@dataclass(frozen=True)
+class DestroyResult:
+    """Outcome of the v3 belt-and-suspenders destroy protocol.
+
+    Exactly one of ``verdict`` (DestroyVerdict) or ``refusal``
+    (DestroyRefusal) is set. The structured fields carry the
+    diagnostic context for the verdict path; the refusal path
+    uses stable message synthesis in the factory.
+
+    The fields below are the v3 contract. No generic ``error``
+    field exists — refusals carry structured refusal reasons,
+    verdicts carry per-step status and error strings.
+    """
+    verdict: Optional[DestroyVerdict] = None
+    refusal: Optional[DestroyRefusal] = None
+    attempts: int = 0
+    last_status_code: int = 0
+    stop_error: str = ""
+    verify_error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# destroy_vastai_instance — amended signature
+# ---------------------------------------------------------------------------
+
+
+def destroy_vastai_instance(
+    instance_id: str,
+    *,
+    ownership: OwnershipPolicy,
+    credentials: Optional[CredentialResolution] = None,
+) -> DestroyResult:
+    """Stop + delete + verify a Vast.ai instance.
+
+    Args:
+        instance_id: Vast.ai instance ID.
+        ownership: Shared ownership policy. The runner and the
+            cleanup adapter both pass the same instance.
+        credentials: Pre-resolved credential state. When None
+            (the default), falls back to ``read_vastai_api_key()``
+            — preserves the v3 back-compat path for direct callers.
+
+    Returns:
+        ``DestroyResult`` with either ``verdict`` or ``refusal``
+        (never both).
+
+    Behaviour by credential state:
+        - EXPLICITLY_DISABLED → refusal CREDENTIALS_DISABLED
+        - ABSENT → refusal NO_CREDENTIALS (the v4 factory
+          intercepts this and runs the CLI fallback)
+        - AVAILABLE → REST path: ownership check via API, then
+          belt-and-suspenders (stop → DELETE×retry → verify →
+          re-destroy). Returns DESTROYED / LEAKED / UNKNOWN.
+
+    CLI fallback is performed by the v4 factory, not by this
+    adapter (the v3 contract keeps the adapter's credential
+    handling simple and stateless).
+    """
+    resolution = credentials or read_vastai_api_key()
+    if resolution.state == CredentialState.EXPLICITLY_DISABLED:
+        return DestroyResult(refusal=DestroyRefusal.CREDENTIALS_DISABLED)
+    if resolution.state == CredentialState.ABSENT:
+        return DestroyResult(refusal=DestroyRefusal.NO_CREDENTIALS)
+    # AVAILABLE: REST path.
+    # ... ownership check via API, belt-and-suspenders, return
+    # DestroyResult with verdict=DESTROYED/LEAKED/UNKNOWN ...
 ```
 
-## `VastaiProviderConfig` shape
+## `providers/vastai.py` — full module updates
 
-The canonical config is a frozen dataclass that owns both the
-runner-side and the policy-side configuration. The runner factory
-and the cleanup-policy factory both read from it.
+The `VastaiProviderConfig`, `VastaiRunner`, `list_vastai_instances`,
+and `build_vastai_cleanup_policy` shapes.
 
 ```python
 # src/vastai_gpu_runner/providers/vastai.py
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import AbstractSet, Optional
+
+from vastai_gpu_runner.cleanup_policy import (
+    CleanupRefusal,
+    CleanupResult,
+    CleanupVerdict,
+    InstanceCandidate,
+    OwnershipPolicy,
+    ProviderCleanupPolicy,
+)
+from vastai_gpu_runner.providers.destroy_adapters.vastai import (
+    CredentialResolution,
+    CredentialState,
+    DestroyRefusal,
+    DestroyResult,
+    DestroyVerdict,
+    destroy_vastai_instance,
+    read_vastai_api_key,
+    vastai_cmd,
+    verify_instance_ownership,
+)
+from vastai_gpu_runner.runner import CloudRunner
+from vastai_gpu_runner.ssh import scp_download, scp_upload, ssh_cmd
+from vastai_gpu_runner.types import (
+    CloudInstance,
+    DeploymentConfig,
+    InstanceStatus,
+    Provider,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_IMAGE = "nvidia/cuda:12.4.0-devel-ubuntu22.04"
+MIN_GPU_VRAM_MIB = 20_000
+
+# States that are already-destroyed or otherwise terminal. Anything
+# not in this set is processed by the cleanup policy. Using a negative
+# allowlist (terminal-skip) is conservative: new Vast.ai states that
+# are not yet terminal are processed, not silently skipped.
+VASTAI_TERMINAL_STATES: frozenset[str] = frozenset({"destroyed"})
+
+
+# ---------------------------------------------------------------------------
+# VastaiProviderConfig
+# ---------------------------------------------------------------------------
+
+
 @dataclass(frozen=True)
 class VastaiProviderConfig:
     """Canonical Vast.ai configuration shared by runner factory + cleanup policy.
 
-    Both ``VastaiRunner.from_config(config)`` and
-    ``build_vastai_cleanup_policy(config)`` read from this. The
-    same instance is passed to both at boot time, so the ownership
-    guard, the credential state, and the deployment identity cannot
-    drift.
+    The runner factory (``VastaiRunner.from_config``) reads
+    ``ownership``, ``credentials``, ``docker_image``, and
+    ``setup_commands`` from this. The cleanup-policy factory
+    (``build_vastai_cleanup_policy``) reads only ``ownership`` and
+    ``credentials`` — the deployment-image invariant does not apply
+    to listing/cleanup-only commands.
 
     Invariants:
         - ``docker_image`` is non-empty and pre-stripped.
@@ -420,124 +815,57 @@ class VastaiProviderConfig:
         Note: explicit empty ``docker_image`` is rejected by
         ``__post_init__``; only ``None`` triggers the default.
         """
-        from vastai_gpu_runner.providers.destroy_adapters.vastai import (
-            read_vastai_api_key,
-        )
         resolved_image = DEFAULT_IMAGE if docker_image is None else docker_image
         return cls(
             docker_image=resolved_image,
             ownership=OwnershipPolicy(owned_images=owned_images),
             credentials=read_vastai_api_key(),
         )
-```
 
-## Vast.ai adapter signature change (v3 amendment)
 
-The v3 design's `destroy_vastai_instance` accepts
-`instance_id` and `allowed_images: frozenset[str]`. The v4 design
-extends this signature: `allowed_images` is replaced by
-`ownership: OwnershipPolicy`, and `credentials` is added as an
-optional parameter (defaults to `read_vastai_api_key()` for
-back-compat direct callers).
+# ---------------------------------------------------------------------------
+# VastaiRunner — full shape (delegates destroy to v3 adapter)
+# ---------------------------------------------------------------------------
 
-The v3 implementation must adopt this signature when it lands. The
-canonical runner and cleanup-policy construction pass the
-`OwnershipPolicy` instance unchanged (no conversion to a set).
 
-```python
-# src/vastai_gpu_runner/providers/destroy_adapters/vastai.py (v3 + v4 signature)
-def destroy_vastai_instance(
-    instance_id: str,
-    *,
-    ownership: OwnershipPolicy,
-    credentials: Optional[CredentialResolution] = None,
-) -> DestroyResult:
-    """Stop + delete + verify a Vast.ai instance.
+class VastaiRunner(CloudRunner):
+    """Vast.ai marketplace runner with hardened deployment.
 
     Args:
-        instance_id: Vast.ai instance ID.
-        ownership: Shared ownership policy. The runner and the
-            cleanup adapter both pass the same instance.
-        credentials: Pre-resolved credential state. When None
-            (the default), falls back to ``read_vastai_api_key()``
-            — preserves the v3 back-compat path for direct callers.
+        config: Deployment configuration.
+        ownership: Ownership policy. The runner and the cleanup
+            adapter both call ``ownership.matches(image_ref)``.
+        credentials: Pre-resolved credential state. When None,
+            the runner uses ``read_vastai_api_key()`` (the v3
+            back-compat path).
+        docker_image: Docker image to use for new instances.
+        min_gpu_vram_mib: Minimum GPU VRAM required (default 20 GB).
+        setup_commands: Optional pre-instance setup commands.
 
-    Returns:
-        ``DestroyResult`` with either ``verdict`` or ``refusal``
-        (never both). The cleanup policy translates this into a
-        ``CleanupResult`` with ``CleanupVerdict`` or
-        ``CleanupRefusal``.
+    Note: ``allowed_images`` is a deprecated back-compat alias
+    that builds an ``OwnershipPolicy`` from the given set. Simultaneous
+    ``ownership=`` and ``allowed_images=`` raises ``ValueError`` —
+    silently ignoring one destruction-safety configuration is unsafe.
     """
-    resolution = credentials or read_vastai_api_key()
-    # ... rest unchanged from v3 design, but using ownership.matches()
-    # instead of the raw _image_is_allowed set check ...
-```
 
-The v2 `verify_instance_ownership` helper is updated to accept
-`OwnershipPolicy` directly:
-
-```python
-# src/vastai_gpu_runner/providers/vastai.py (v4 amendment)
-def verify_instance_ownership(
-    instance_id: str,
-    *,
-    ownership: OwnershipPolicy,
-) -> bool:
-    """Check that a Vast.ai instance belongs to the caller before destruction.
-
-    Uses ``ownership.matches(image_uuid)`` for the ownership check.
-    """
-    if ownership.owned_images is None:
-        return True
-    try:
-        raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
-        instances = json.loads(raw)
-    except (RuntimeError, json.JSONDecodeError) as exc:
-        logger.warning(
-            "Cannot verify ownership of instance %s (API error: %s) — refusing to destroy",
-            instance_id,
-            exc,
-        )
-        return False
-    inst = _find_instance(instances, instance_id)
-    if inst is None:
-        logger.info("Instance %s not found in account (already destroyed?)", instance_id)
-        return True
-    image = str(inst.get("image_uuid", ""))
-    if ownership.matches(image):
-        return True
-    logger.error(
-        "BLOCKED: instance %s belongs to another project (image=%s). Will NOT destroy.",
-        instance_id,
-        image,
-    )
-    return False
-```
-
-## `VastaiRunner` shape
-
-The `__init__` keeps the `allowed_images` parameter as a deprecated
-back-compat path (it builds an `OwnershipPolicy` from it). The
-`from_config` classmethod is the canonical entry point.
-
-```python
-# src/vastai_gpu_runner/providers/vastai.py (VastaiRunner updates)
-class VastaiRunner(CloudRunner):
     def __init__(
         self,
         config: DeploymentConfig | None = None,
         *,
         ownership: OwnershipPolicy | None = None,
-        allowed_images: frozenset[str] | None = None,  # DEPRECATED: build OwnershipPolicy instead
+        credentials: CredentialResolution | None = None,
+        allowed_images: frozenset[str] | None = None,  # DEPRECATED
         docker_image: str = DEFAULT_IMAGE,
         min_gpu_vram_mib: int = MIN_GPU_VRAM_MIB,
         setup_commands: list[str] | None = None,
     ) -> None:
-        """Initialize Vast.ai runner with deployment config and safety guards."""
+        if ownership is not None and allowed_images is not None:
+            raise ValueError(
+                "VastaiRunner: supply either ownership= or allowed_images= "
+                "(deprecated), not both — silently ignoring one destruction-"
+                "safety configuration is unsafe."
+            )
         if ownership is None and allowed_images is not None:
-            # Back-compat: build OwnershipPolicy from the deprecated set.
-            import warnings
-
             warnings.warn(
                 "VastaiRunner(allowed_images=...) is deprecated; "
                 "build an OwnershipPolicy and pass ownership= instead.",
@@ -547,7 +875,8 @@ class VastaiRunner(CloudRunner):
             ownership = OwnershipPolicy(owned_images=frozenset(allowed_images))
         super().__init__(config)
         self.ownership = ownership
-        # Preserve .allowed_images as a property for back-compat reads.
+        self.credentials = credentials
+        # Back-compat read access for existing callers.
         self._allowed_images_for_backcompat = (
             frozenset(ownership.owned_images)
             if ownership and ownership.owned_images is not None
@@ -566,59 +895,105 @@ class VastaiRunner(CloudRunner):
     def from_config(cls, canonical: VastaiProviderConfig) -> "VastaiRunner":
         """Build a VastaiRunner from the canonical config.
 
-        Passes the canonical ``OwnershipPolicy`` instance unchanged
-        — the runner and the cleanup policy will call the same
-        ``matches()`` method on the same instance.
+        Preserves the canonical ``OwnershipPolicy`` and
+        ``CredentialResolution`` instances unchanged — the runner
+        and the cleanup policy will call ``ownership.matches()`` and
+        use ``credentials`` from the same instances.
         """
         return cls(
             ownership=canonical.ownership,
+            credentials=canonical.credentials,
             docker_image=canonical.docker_image,
             min_gpu_vram_mib=canonical.min_gpu_vram_mib,
             setup_commands=list(canonical.setup_commands),
         )
 
+    # ... wait_for_boot, verify_gpu, deploy_files, setup_environment,
+    # launch_worker, check_progress, list_remote_files, download_file,
+    # capture_deploy_failure_diagnostics: unchanged from v2 ...
+
     def destroy_instance(self, instance: CloudInstance) -> bool:
-        """Destroy a Vast.ai instance (with ownership safety guard)."""
-        if not verify_instance_ownership(
+        """Destroy a Vast.ai instance — delegates entirely to the v3 adapter.
+
+        The v2 implementation did inline ownership pre-check +
+        CLI destroy + belt-and-suspenders REST destroy + always
+        returned True. The v3 design moves all of that into
+        ``destroy_vastai_instance`` (the adapter); this method is
+        a single adapter call with no inline destroy logic.
+
+        Returns True iff the adapter reports ``verdict=DESTROYED``.
+        LEAKED, UNKNOWN, and all refusals return False.
+        """
+        result = destroy_vastai_instance(
             instance.instance_id,
             ownership=self.ownership or OwnershipPolicy(),
-        ):
+            credentials=self.credentials,
+        )
+        if result.verdict == DestroyVerdict.DESTROYED:
+            instance.status = InstanceStatus.DESTROYED
+            return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# verify_instance_ownership — uses OwnershipPolicy.matches()
+# ---------------------------------------------------------------------------
+
+
+def verify_instance_ownership(
+    instance_id: str,
+    *,
+    ownership: OwnershipPolicy,
+) -> bool:
+    """Check that a Vast.ai instance belongs to the caller before destruction.
+
+    Uses ``ownership.matches(image_uuid)`` for the ownership check.
+    This is the CLI-auth verification used by the v4 factory's
+    CLI fallback path (separate auth context from the REST path).
+    """
+    if ownership.owned_images is None:
+        return True
+    try:
+        raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
+        instances = json.loads(raw)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Cannot verify ownership of instance %s (API error: %s) — refusing to destroy",
+            instance_id,
+            exc,
+        )
+        return False
+    for inst in instances:
+        if str(inst.get("id")) == str(instance_id):
+            image = str(inst.get("image_uuid", ""))
+            if ownership.matches(image):
+                return True
             logger.error(
-                "REFUSED to destroy instance %s — ownership check failed.",
-                instance.instance_id,
+                "BLOCKED: instance %s belongs to another project (image=%s). Will NOT destroy.",
+                instance_id,
+                image,
             )
             return False
-        # ... rest unchanged from v2 ...
-```
+    logger.info("Instance %s not found in account (already destroyed?)", instance_id)
+    return True
 
-## `list_vastai_instances` shape
 
-The provider's read-only enumeration helper. The Vast.ai factory
-wraps this with the EXPLICITLY_DISABLED short-circuit; the core
-helper is unchanged.
-
-```python
-# src/vastai_gpu_runner/providers/vastai.py
-# Module-level constant: states that are safe for the cleanup sweep to
-# act on. Anything not in this set returns CleanupRefusal.INELIGIBLE_STATE
-# from the factory's _destroy callback.
-VASTAI_ELIGIBLE_STATES: frozenset[str] = frozenset(
-    {"running", "stopped", "exited", "loading", "created"}
-)
+# ---------------------------------------------------------------------------
+# list_vastai_instances — validates instance_id non-empty
+# ---------------------------------------------------------------------------
 
 
 def list_vastai_instances() -> list[InstanceCandidate]:
     """Read-only enumeration of Vast.ai instances on this account.
 
-    Returns ``InstanceCandidate`` records so the orchestrator's
-    zombie sweep does not have to parse Vast.ai's JSON shape. A
-    failure to enumerate returns an empty list — the orchestrator's
-    existing exception handling logs the failure and continues.
+    Returns ``InstanceCandidate`` records. Records with missing
+    or empty ``instance_id`` are skipped (logged). A failure to
+    enumerate returns an empty list.
 
     NB: this helper does NOT enforce the EXPLICITLY_DISABLED
     short-circuit. The factory wraps this function with the
-    short-circuit so the policy's list_instances() honors the v3
-    contract.
+    short-circuit so the policy's ``list_instances()`` honors the
+    v3 contract.
     """
     candidates: list[InstanceCandidate] = []
     try:
@@ -628,14 +1003,21 @@ def list_vastai_instances() -> list[InstanceCandidate]:
         logger.warning("list_vastai_instances: enumeration failed: %s", exc)
         return candidates
     for inst in instances:
+        instance_id = str(inst.get("id", "")).strip()
+        if not instance_id:
+            logger.warning(
+                "Skipping instance with missing ID: %s",
+                {k: inst.get(k) for k in ("label", "image_uuid", "actual_status")},
+            )
+            continue
         try:
             image_uuid = str(inst.get("image_uuid", ""))
             candidates.append(
                 InstanceCandidate(
                     provider=Provider.VASTAI,
-                    instance_id=str(inst.get("id", "")),
+                    instance_id=instance_id,
                     image_uuid=image_uuid,
-                    ownership_key=image_uuid,  # Vast.ai's ownership key is its image
+                    ownership_key=image_uuid,  # Vast.ai: image_uuid is the ownership key
                     gpu_model=str(inst.get("gpu_name", "")),
                     cost_per_hour=float(inst.get("dph_total", 0.0) or 0.0),
                     label=str(inst.get("label", "")),
@@ -646,244 +1028,48 @@ def list_vastai_instances() -> list[InstanceCandidate]:
         except (TypeError, ValueError) as exc:
             logger.warning("Skipping malformed instance: %s", exc)
     return candidates
-```
-
-## `InstanceCandidate`, `CleanupVerdict`, `CleanupRefusal`, `CleanupResult` shapes
-
-```python
-# src/vastai_gpu_runner/cleanup_policy.py (additions)
 
 
-class CleanupVerdict(Enum):
-    """Outcome verdicts returned by ``policy.destroy``.
-
-    These are protocol outcomes — the destroy protocol ran to
-    completion and reported a verdict. ``DESTROYED`` is the only
-    success; the others are observable non-success states that
-    the orchestrator logs distinctly.
-    """
-
-    DESTROYED = "destroyed"
-    CLI_ATTEMPTED = "cli_attempted"  # CLI fallback ran, destruction not confirmed
-    LEAKED = "leaked"                # Protocol ran but instance was resurrected
-    UNKNOWN = "unknown"              # Protocol did not report a clear outcome
+# ---------------------------------------------------------------------------
+# build_vastai_cleanup_policy — the v4 factory
+# ---------------------------------------------------------------------------
 
 
-class CleanupRefusal(Enum):
-    """Pre-protocol refusal reasons returned by ``policy.destroy``.
-
-    These are policy-level decisions — the destroy protocol is
-    never entered. The orchestrator logs the refusal and skips
-    the candidate.
-    """
-
-    OWNERSHIP = "ownership"               # image/template not owned by this policy
-    NO_CREDENTIALS = "no_credentials"     # no API key configured; CLI fallback attempted
-    CREDENTIALS_DISABLED = "credentials_disabled"  # VASTAI_API_KEY="" — CLI fallback forbidden
-    INELIGIBLE_STATE = "ineligible_state" # candidate.state not in provider's eligible_states
-    PROVIDER_MISMATCH = "provider_mismatch"  # candidate.provider != policy.provider
-
-
-@dataclass(frozen=True)
-class InstanceCandidate:
-    """Read-only snapshot of one instance returned by ``list_*_instances``.
-
-    Frozen so the policy can hold it without aliasing surprises.
-    Fields are the union of what every provider can feasibly
-    expose; providers that do not have a field (e.g. RunPod has
-    no ``image_uuid``) leave it empty.
-
-    For the CLI's instance listing, ``gpu_model`` and
-    ``cost_per_hour`` provide the table data without the
-    orchestrator having to parse provider JSON.
-    """
-
-    provider: "Provider"
-    instance_id: str
-    label: str
-    state: str
-    image_uuid: str = ""           # Vast.ai: Docker image reference
-    ownership_key: str = ""        # Generic: any provider's ownership token
-    gpu_model: str = ""
-    cost_per_hour: float = 0.0
-    started_at: float = 0.0
-
-
-@dataclass(frozen=True)
-class CleanupResult:
-    """Outcome of ``policy.destroy``.
-
-    Exactly one of ``verdict`` (CleanupVerdict) or ``refusal``
-    (CleanupRefusal) is set — never both, never neither. ``error``
-    is non-empty on every non-DESTROYED outcome (it carries the
-    structured diagnostic context); ``error`` is empty on
-    DESTROYED (success has no error).
-
-    The cleanup policy wraps the v3 ``DestroyResult`` (which has
-    ``verdict: DestroyVerdict`` + ``refusal: DestroyRefusal``)
-    in this tighter shape for the orchestrator.
-    """
-
-    verdict: Optional[CleanupVerdict] = None
-    refusal: Optional[CleanupRefusal] = None
-    error: str = ""
-
-    def __post_init__(self) -> None:
-        if (self.verdict is None) == (self.refusal is None):
-            raise ValueError(
-                "CleanupResult: exactly one of verdict or refusal must be set"
-            )
-        if self.verdict == CleanupVerdict.DESTROYED:
-            if self.error:
-                raise ValueError(
-                    "CleanupResult.DESTROYED must have empty error"
-                )
-        elif not self.error:
-            ident = (
-                self.verdict.value
-                if self.verdict is not None
-                else self.refusal.value
-            )
-            raise ValueError(
-                f"CleanupResult: {ident} must have non-empty error"
-            )
-```
-
-## `ProviderCleanupPolicy` shape
-
-```python
-# src/vastai_gpu_runner/cleanup_policy.py (policy class)
-@dataclass(frozen=True, kw_only=True)
-class ProviderCleanupPolicy:
-    """Per-provider cleanup contract.
-
-    The core module is provider-agnostic: it imports nothing from
-    ``providers/``. The ``list_instances_fn`` and ``destroy_fn``
-    callbacks are wired by the provider-owned factory (e.g.
-    ``build_vastai_cleanup_policy``).
-
-    Args:
-        provider: Which provider this policy applies to.
-        ownership: Shared ownership semantics. The runner and the
-            cleanup adapter both call ``ownership.matches(image_ref)``.
-        list_instances_fn: Callable that returns a complete
-            ``list[InstanceCandidate]``. Wired by the adapter.
-            The factory may wrap the provider's list helper with
-            the EXPLICITLY_DISABLED short-circuit.
-        destroy_fn: Callable that takes one ``InstanceCandidate``,
-            applies the eligibility / ownership / credential
-            checks authoritatively, and returns a ``CleanupResult``.
-            The factory wires the v3 ``destroy_vastai_instance``
-            (with CLI fallback) here.
-
-    Why two callbacks (list + destroy) and not one: the
-    orchestrator's outer loop separates enumeration from
-    destruction per candidate. The destroy path needs to be
-    callable without re-enumerating (the candidate was already
-    selected). One callback per phase keeps the contract narrow.
-    """
-
-    provider: "Provider"
-    ownership: OwnershipPolicy
-    list_instances_fn: Callable[[], list[InstanceCandidate]] = field(repr=False)
-    destroy_fn: Callable[[InstanceCandidate], CleanupResult] = field(repr=False)
-
-    def list_instances(self) -> list[InstanceCandidate]:
-        """Read-only enumeration of provider instances.
-
-        The orchestrator's ``_sweep_zombies`` calls this once per
-        sweep. Failures are caught and logged by the orchestrator.
-        The provider factory may wrap the underlying helper with
-        the EXPLICITLY_DISABLED short-circuit.
-        """
-        try:
-            return self.list_instances_fn()
-        except Exception as exc:
-            logger.warning("Cleanup policy: list_instances raised: %s", exc)
-            return []
-
-    def destroy(self, candidate: InstanceCandidate) -> CleanupResult:
-        """Run the per-provider destroy on one candidate.
-
-        Authoritative gate: this method re-validates the
-        candidate's provider identity (PROVIDER_MISMATCH refusal)
-        on every call, then delegates to ``destroy_fn`` which
-        applies eligibility / ownership / credential checks.
-
-        Never raises. The orchestrator must be able to log the
-        result and continue to the next candidate.
-        """
-        if candidate.provider != self.provider:
-            return CleanupResult(
-                refusal=CleanupRefusal.PROVIDER_MISMATCH,
-                error=(
-                    f"candidate {candidate.instance_id!r} belongs to "
-                    f"provider {candidate.provider.value!r}; cleanup "
-                    f"policy expects {self.provider.value!r}"
-                ),
-            )
-        try:
-            return self.destroy_fn(candidate)
-        except Exception as exc:
-            logger.warning(
-                "Cleanup: destroy_fn raised for %s: %s",
-                candidate.instance_id,
-                exc,
-            )
-            return CleanupResult(
-                verdict=CleanupVerdict.UNKNOWN,
-                error=str(exc),
-            )
-```
-
-## `build_vastai_cleanup_policy` shape
-
-The provider-owned factory. This is the only place that combines
-v3's `destroy_vastai_instance` with the v4 policy. It lives in
-`providers/vastai.py` so the core module has no provider imports.
-
-```python
-# src/vastai_gpu_runner/providers/vastai.py
 def build_vastai_cleanup_policy(
-    canonical: VastaiProviderConfig,
+    *,
+    ownership: OwnershipPolicy,
+    credentials: CredentialResolution,
 ) -> ProviderCleanupPolicy:
-    """Build a Vast.ai cleanup policy from the canonical config.
+    """Build a Vast.ai cleanup policy from the canonical objects.
 
-    The canonical config (the same ``VastaiProviderConfig`` passed
-    to ``VastaiRunner.from_config``) is the source of truth for the
-    ownership policy, the credential resolution, and the deployment
-    identity. Reading from the same source guarantees the destroy
-    ownership guard and the runner's ownership guard cannot drift.
+    The two arguments are the same ``OwnershipPolicy`` and
+    ``CredentialResolution`` instances that the runner was
+    constructed with (the batch command extracts them from the
+    ``VastaiProviderConfig``; the cleanup command constructs them
+    directly from CLI args).
 
     The wired ``list_instances_fn`` enforces the v3 contract:
-    EXPLICITLY_DISABLED credentials return [] without invoking
-    CLI enumeration (no API key, no CLI fallback — fail-closed).
+    ``EXPLICITLY_DISABLED`` credentials return ``[]`` without
+    invoking CLI enumeration (no API key, no CLI fallback — fail-closed).
 
-    The wired ``destroy_fn`` translates the v3 DestroyResult into
-    the v4 CleanupResult, preserving all four verdicts and all
-    three refusals.
+    The wired ``destroy_fn`` runs:
+        1. Eligibility check (skip terminal states like ``destroyed``).
+        2. ``destroy_vastai_instance`` with the canonical ownership + credentials.
+        3. If the adapter returns ``NO_CREDENTIALS``, run the CLI
+           fallback path: CLI ownership verification → CLI destroy →
+           ``CLI_ATTEMPTED`` (destruction unconfirmed) or ``UNKNOWN``.
+        4. Translate all three v3 verdicts and all three v3 refusals
+           into the v4 ``CleanupResult`` shape, with diagnostic text
+           built from the structured ``DestroyResult`` fields.
     """
-    from vastai_gpu_runner.cleanup_policy import (
-        CleanupRefusal,
-        CleanupResult,
-        CleanupVerdict,
-        OwnershipPolicy,
-        ProviderCleanupPolicy,
-    )
-    from vastai_gpu_runner.providers.destroy import (
-        DestroyRefusal,
-        DestroyVerdict,
-    )
-    from vastai_gpu_runner.providers.destroy_adapters.vastai import (
-        destroy_vastai_instance,
-    )
+    provider = Provider.VASTAI
 
     def _list_instances() -> list[InstanceCandidate]:
         # v3 contract: EXPLICITLY_DISABLED short-circuits before
         # CLI enumeration. The CLI fallback path uses file
         # credentials which would silently bypass the explicit
         # disable — fail-closed.
-        if canonical.credentials.state == CredentialState.EXPLICITLY_DISABLED:
+        if credentials.state == CredentialState.EXPLICITLY_DISABLED:
             logger.warning(
                 "Zombie sweep disabled: VASTAI_API_KEY is explicitly empty; "
                 "provider enumeration was not attempted."
@@ -891,60 +1077,119 @@ def build_vastai_cleanup_policy(
             return []
         return list_vastai_instances()
 
-    def _destroy(candidate: InstanceCandidate) -> CleanupResult:
-        # Authoritative eligibility check (per v4 CONCERN 9).
-        if candidate.state not in VASTAI_ELIGIBLE_STATES:
+    def _describe(result: DestroyResult) -> str:
+        """Build diagnostic text from v3 DestroyResult structured fields."""
+        return (
+            f"attempts={result.attempts}, "
+            f"last_status={result.last_status_code}, "
+            f"verify_error={result.verify_error!r}, "
+            f"stop_error={result.stop_error!r}"
+        )
+
+    def _cli_fallback(candidate: InstanceCandidate) -> CleanupResult:
+        """CLI fallback path for ABSENT credentials.
+
+        The v3 adapter returns NO_CREDENTIALS when the API key is
+        not configured. We then verify ownership via the CLI auth
+        context (which uses the file-based key), and if owned, run
+        the CLI destroy. CLI destruction is unconfirmed — we report
+        CLI_ATTEMPTED, not DESTROYED.
+        """
+        try:
+            if not verify_instance_ownership(
+                candidate.instance_id,
+                ownership=ownership,
+            ):
+                return CleanupResult(
+                    refusal=CleanupRefusal.OWNERSHIP,
+                    error=(
+                        "CLI ownership check rejected "
+                        f"{candidate.instance_id!r}"
+                    ),
+                )
+        except Exception as exc:
             return CleanupResult(
-                refusal=CleanupRefusal.INELIGIBLE_STATE,
+                verdict=CleanupVerdict.UNKNOWN,
                 error=(
-                    f"state {candidate.state!r} not in "
-                    f"VASTAI_ELIGIBLE_STATES={set(VASTAI_ELIGIBLE_STATES)!r}"
+                    f"CLI ownership verification raised "
+                    f"{type(exc).__name__}: {exc}"
                 ),
             )
-        # CREDENTIALS_DISABLED: refuse without provider calls.
-        if canonical.credentials.state == CredentialState.EXPLICITLY_DISABLED:
+        try:
+            vastai_cmd(["destroy", "instance", candidate.instance_id], timeout=15)
+            return CleanupResult(
+                verdict=CleanupVerdict.CLI_ATTEMPTED,
+                error=(
+                    "CLI fallback ran; destruction not confirmed via REST"
+                ),
+            )
+        except Exception as exc:
+            return CleanupResult(
+                verdict=CleanupVerdict.UNKNOWN,
+                error=f"CLI destroy raised {type(exc).__name__}: {exc}",
+            )
+
+    def _destroy(candidate: InstanceCandidate) -> CleanupResult:
+        # 1. Eligibility check (negative allowlist: skip terminal states).
+        if not candidate.state:
+            return CleanupResult(
+                refusal=CleanupRefusal.INELIGIBLE_STATE,
+                error="empty state",
+            )
+        if candidate.state in VASTAI_TERMINAL_STATES:
+            return CleanupResult(
+                refusal=CleanupRefusal.INELIGIBLE_STATE,
+                error=f"state {candidate.state!r} is terminal (already destroyed)",
+            )
+        # 2. CREDENTIALS_DISABLED: refuse without provider calls.
+        # (Should already be short-circuited at enumeration, but
+        # belt-and-suspenders in case a candidate was created by
+        # another path.)
+        if credentials.state == CredentialState.EXPLICITLY_DISABLED:
             return CleanupResult(
                 refusal=CleanupRefusal.CREDENTIALS_DISABLED,
                 error="VASTAI_API_KEY explicitly empty",
             )
-        # Delegate to v3 adapter with the canonical ownership + credentials.
+        # 3. Delegate to v3 adapter with the canonical ownership + credentials.
         result = destroy_vastai_instance(
             candidate.instance_id,
-            ownership=canonical.ownership,
-            credentials=canonical.credentials,
+            ownership=ownership,
+            credentials=credentials,
         )
-        # Translate refusals first.
-        if result.refusal is not None:
-            mapping = {
-                DestroyRefusal.OWNERSHIP: CleanupRefusal.OWNERSHIP,
-                DestroyRefusal.NO_CREDENTIALS: CleanupRefusal.NO_CREDENTIALS,
-                DestroyRefusal.CREDENTIALS_DISABLED: CleanupRefusal.CREDENTIALS_DISABLED,
-            }
+        # 4. Translate refusals first.
+        if result.refusal == DestroyRefusal.NO_CREDENTIALS:
+            return _cli_fallback(candidate)
+        if result.refusal == DestroyRefusal.OWNERSHIP:
             return CleanupResult(
-                refusal=mapping[result.refusal],
-                error=result.error,
+                refusal=CleanupRefusal.OWNERSHIP,
+                error=(
+                    f"v3 adapter refused: ownership check rejected "
+                    f"{candidate.instance_id!r}"
+                ),
             )
-        # Translate verdicts exhaustively.
+        if result.refusal == DestroyRefusal.CREDENTIALS_DISABLED:
+            return CleanupResult(
+                refusal=CleanupRefusal.CREDENTIALS_DISABLED,
+                error=(
+                    "v3 adapter refused: VASTAI_API_KEY explicitly empty"
+                ),
+            )
+        # 5. Translate verdicts exhaustively.
         if result.verdict == DestroyVerdict.DESTROYED:
             return CleanupResult(verdict=CleanupVerdict.DESTROYED)
-        if result.verdict == DestroyVerdict.CLI_ATTEMPTED:
-            return CleanupResult(
-                verdict=CleanupVerdict.CLI_ATTEMPTED,
-                error=result.error,
-            )
         if result.verdict == DestroyVerdict.LEAKED:
             return CleanupResult(
                 verdict=CleanupVerdict.LEAKED,
-                error=result.error,
+                error=_describe(result),
             )
         return CleanupResult(
             verdict=CleanupVerdict.UNKNOWN,
-            error=result.error or "v3 adapter returned no verdict",
+            error=_describe(result),
         )
 
     return ProviderCleanupPolicy(
-        provider=Provider.VASTAI,
-        ownership=canonical.ownership,
+        provider=provider,
+        ownership=ownership,
         list_instances_fn=_list_instances,
         destroy_fn=_destroy,
     )
@@ -952,11 +1197,16 @@ def build_vastai_cleanup_policy(
 
 ## Orchestrator wiring
 
-The orchestrator's `_sweep_zombies` becomes policy-driven end-to-end.
-The orchestrator logs every non-`DESTROYED` outcome.
+The orchestrator's `_sweep_zombies` is policy-driven end-to-end.
+The orchestrator logs every non-`DESTROYED` outcome at severity
+matching operational impact.
 
 ```python
 # src/vastai_gpu_runner/batch.py (changes to _sweep_zombies)
+# NB: `logger` is the module-level logger already defined at the
+# top of batch.py (`logger = logging.getLogger(__name__)`). This
+# block shows only the new/changed logic.
+
 def _sweep_zombies(self) -> int:
     """Destroy orphaned instances not tracked by live_runners.
 
@@ -967,12 +1217,8 @@ def _sweep_zombies(self) -> int:
     3. Exclude tracked IDs (the existing semantics).
     4. For every remaining candidate, call ``policy.destroy(candidate)``.
     5. Count ``verdict == DESTROYED`` outcomes.
-    6. Log every non-DESTROYED outcome distinctly.
-
-    The orchestrator does NOT branch on Provider, does NOT import
-    provider modules, and does NOT call any provider-specific
-    destroy function. The policy owns the eligibility / ownership
-    / credential decisions.
+    6. Log every non-DESTROYED outcome with severity matching
+       operational impact.
     """
     with self._state_lock:
         tracked_ids = {
@@ -980,9 +1226,6 @@ def _sweep_zombies(self) -> int:
         }
     candidates = self._cleanup_policy.list_instances()
     killed = 0
-    cli_attempted = 0
-    leaked = 0
-    unknown = 0
     for candidate in candidates:
         if not candidate.label.startswith(self._label_prefix):
             continue
@@ -992,46 +1235,63 @@ def _sweep_zombies(self) -> int:
         if result.verdict == CleanupVerdict.DESTROYED:
             killed += 1
             continue
-        # Log every non-DESTROYED outcome distinctly.
-        kind = (
-            result.verdict.value
-            if result.verdict is not None
-            else result.refusal.value
-        )
-        logger.info(
-            "Zombie sweep: %s outcome=%s: %s",
-            candidate.instance_id,
-            kind,
-            result.error,
-        )
-        if result.verdict == CleanupVerdict.CLI_ATTEMPTED:
-            cli_attempted += 1
-        elif result.verdict == CleanupVerdict.LEAKED:
-            leaked += 1
+        # Severity-by-outcome logging.
+        if result.verdict == CleanupVerdict.LEAKED:
+            logger.error(
+                "Zombie sweep: %s LEAKED — manual review required: %s",
+                candidate.instance_id,
+                result.error,
+            )
         elif result.verdict == CleanupVerdict.UNKNOWN:
-            unknown += 1
+            logger.warning(
+                "Zombie sweep: %s outcome=UNKNOWN: %s",
+                candidate.instance_id,
+                result.error,
+            )
+        elif result.verdict == CleanupVerdict.CLI_ATTEMPTED:
+            logger.warning(
+                "Zombie sweep: %s CLI fallback attempted (destruction not confirmed): %s",
+                candidate.instance_id,
+                result.error,
+            )
+        elif result.refusal == CleanupRefusal.CREDENTIALS_DISABLED:
+            logger.warning(
+                "Zombie sweep: %s refused (credentials disabled): %s",
+                candidate.instance_id,
+                result.error,
+            )
+        elif result.refusal in (
+            CleanupRefusal.OWNERSHIP,
+            CleanupRefusal.INELIGIBLE_STATE,
+            CleanupRefusal.PROVIDER_MISMATCH,
+        ):
+            logger.info(
+                "Zombie sweep: %s refused (%s): %s",
+                candidate.instance_id,
+                result.refusal.value,
+                result.error,
+            )
+        elif result.refusal == CleanupRefusal.NO_CREDENTIALS:
+            # Should not reach here — the factory's CLI fallback
+            # intercepts NO_CREDENTIALS. Logged for visibility.
+            logger.info(
+                "Zombie sweep: %s refused (no credentials): %s",
+                candidate.instance_id,
+                result.error,
+            )
     if killed:
         logger.info("Zombie sweep: destroyed %d instance(s)", killed)
-    if cli_attempted:
-        logger.info(
-            "Zombie sweep: %d CLI fallback(s) attempted (destruction not confirmed)",
-            cli_attempted,
-        )
-    if leaked:
-        logger.warning("Zombie sweep: %d LEAKED instance(s) — manual review needed", leaked)
-    if unknown:
-        logger.warning("Zombie sweep: %d UNKNOWN outcome(s)", unknown)
     return killed
 ```
 
 The orchestrator's `__init__` requires `cleanup_policy: ProviderCleanupPolicy`
-and `runner_factory: RunnerFactory`. The `runner_factory` is preserved for
-the deploy path; only the ownership guard migrates.
+and `runner_factory: RunnerFactory`.
 
 ## CLI wiring
 
-The CLI is the one place that builds the canonical config and the
-runner factory. It threads the same config into the policy factory.
+The CLI is the one place that builds the canonical config (for the
+runner) and the two canonical objects (for the cleanup policy). It
+threads both into the v3 + v4 entry points.
 
 ```python
 # src/vastai_gpu_runner/cli.py (new "batch" subcommand)
@@ -1054,8 +1314,6 @@ def batch(
     )
 
     # Step 1: one canonical config, frozen, immutable.
-    # `from_env` returns the base (credentials loaded, defaults
-    # applied); `replace` overlays the project-specific values.
     base = VastaiProviderConfig.from_env()
     config = replace(
         base,
@@ -1066,8 +1324,12 @@ def batch(
     # Step 2: runner factory reads from the same config.
     runner_factory = lambda: VastaiRunner.from_config(config)  # noqa: E731
 
-    # Step 3: cleanup policy reads from the same config.
-    cleanup_policy = build_vastai_cleanup_policy(config)
+    # Step 3: cleanup policy reads ownership + credentials from the
+    # same config (no deployment-image wrapper needed).
+    cleanup_policy = build_vastai_cleanup_policy(
+        ownership=config.ownership,
+        credentials=config.credentials,
+    )
 
     orch = MyOrchestrator(
         runner_factory=runner_factory,
@@ -1077,19 +1339,19 @@ def batch(
     orch.run()
 ```
 
-The existing `cli.py:cleanup` and `cli.py:instances` commands
-migrate to use the new API in migration step 5:
+The existing `cli.py:cleanup` command migrates to use the new API
+without constructing a `VastaiProviderConfig` (no deployment image):
 
 ```python
 # src/vastai_gpu_runner/cli.py (cleanup command)
 @app.command()
 def cleanup(
     label_prefix: Annotated[str, typer.Option("--label", "-l")] = ...,
-    owned_images: Annotated[
+    allowed_images: Annotated[
         str | None,
         typer.Option(
-            "--owned-images",
-            "--allowed-images",  # back-compat alias (kept canonical)
+            "--allowed-images",  # canonical
+            "--owned-images",     # alias
             help="Comma-separated Docker images owned by this project",
         ),
     ] = None,
@@ -1103,19 +1365,21 @@ def cleanup(
         CleanupVerdict,
         OwnershipPolicy,
     )
-    from vastai_gpu_runner.providers.vastai import (
-        VastaiProviderConfig,
-        build_vastai_cleanup_policy,
+    from vastai_gpu_runner.providers.destroy_adapters.vastai import (
+        read_vastai_api_key,
     )
+    from vastai_gpu_runner.providers.vastai import build_vastai_cleanup_policy
 
     console = Console()
     ownership = (
-        OwnershipPolicy(owned_images=frozenset(owned_images.split(",")))
-        if owned_images
+        OwnershipPolicy(owned_images=frozenset(allowed_images.split(",")))
+        if allowed_images
         else OwnershipPolicy()
     )
-    config = VastaiProviderConfig.from_env(owned_images=ownership.owned_images)
-    cleanup_policy = build_vastai_cleanup_policy(config)
+    cleanup_policy = build_vastai_cleanup_policy(
+        ownership=ownership,
+        credentials=read_vastai_api_key(),
+    )
 
     candidates = cleanup_policy.list_instances()
     matches = [c for c in candidates if c.label.startswith(label_prefix)]
@@ -1156,271 +1420,221 @@ def cleanup(
 
 ## Migration checklist
 
-Seven steps. The order is the ChatGPT 5th + 6th pass recommendation
-(canonical types first, adapter before orchestrator, audit before
-deletion). Each step is independently testable but the rollout
+Seven steps. Each step is independently testable but the rollout
 lands as one PR because the intermediate states are not stable.
 
 1. **Add canonical credential + ownership-policy types + invariants + contract tests.**
-   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with the v3 `_repository` helper).
-   - `providers/destroy_adapters/vastai.py:CredentialState` + `CredentialResolution` (v3 prerequisite — may already exist if v3 is implemented).
-   - Property tests: `OwnershipPolicy.matches` is reflexive (the owned image matches itself); tag-insensitive (`:1.0` and `:latest` match when the repository is owned); `None` opts out (every image matches); empty set rejects everything (fail-closed); different registry prefixes do not match (`registry:5000/myorg/app` ≠ `registry-malicious/myorg/app`); sha256 digests match by repository; malformed references (multiple `@`, multiple `:`) return `False`.
-   - `CredentialResolution` invariants: `AVAILABLE` requires non-empty pre-stripped key; `ABSENT` and `EXPLICITLY_DISABLED` require empty key.
+   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with the v3 `_repository` helper; declared `_normalised` cache field).
+   - `providers/destroy_adapters/vastai.py:CredentialState` (StrEnum) + `CredentialResolution` (frozen dataclass with `state` and `key` fields).
+   - Property tests: `OwnershipPolicy.matches` is reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets and malformed references.
+   - `CredentialResolution` invariants: AVAILABLE requires non-empty pre-stripped key; ABSENT and EXPLICITLY_DISABLED require empty key.
 
-2. **Add `VastaiProviderConfig` + `VastaiRunner.from_config` + constructor parity.**
-   - `providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership` + `credentials` + `docker_image`).
-   - `__post_init__` invariants: `docker_image` non-empty + pre-stripped; `docker_image ∈ ownership.owned_images` unless ownership is disabled.
-   - `VastaiRunner.from_config(config)` classmethod. Constructor parity test: `VastaiRunner(allowed_images=frozenset({img}), docker_image=img, ...)` (deprecated path) and `VastaiRunner.from_config(VastaiProviderConfig(docker_image=img, ownership=OwnershipPolicy(owned_images=frozenset({img})), ...))` produce equivalent `ownership` attribute values.
-   - `VastaiRunner.__init__` adds `ownership: OwnershipPolicy | None` parameter; `allowed_images` becomes a deprecated alias (emits `DeprecationWarning` when used).
-   - `verify_instance_ownership(instance_id, *, ownership=OwnershipPolicy)` — replaces the raw `allowed_images` set check with `ownership.matches(image_uuid)`. The `_image_is_allowed` helper is **deleted**.
-   - `VastaiProviderConfig.from_env()` reads the v3 `read_vastai_api_key()` into `credentials`.
+2. **Add v3 `DestroyResult` / `DestroyVerdict` / `DestroyRefusal` types + amend adapter signature.**
+   - `providers/destroy_adapters/vastai.py:DestroyVerdict` (StrEnum: `DESTROYED | LEAKED | UNKNOWN`).
+   - `providers/destroy_adapters/vastai.py:DestroyRefusal` (StrEnum: `OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED`).
+   - `providers/destroy_adapters/vastai.py:DestroyResult` (frozen dataclass: `verdict | refusal`, `attempts`, `last_status_code`, `stop_error`, `verify_error` — no `error` field).
+   - `destroy_vastai_instance(instance_id, *, ownership: OwnershipPolicy, credentials: CredentialResolution | None = None) -> DestroyResult`. Back-compat: when `credentials=None`, calls `read_vastai_api_key()`.
+   - Contract tests: ownership match uses `OwnershipPolicy.matches()`; credential state drives refusal type; AVAILABLE runs the REST path; ABSENT returns `NO_CREDENTIALS`; EXPLICITLY_DISABLED returns `CREDENTIALS_DISABLED`.
 
-3. **Add Vast.ai cleanup adapter (enumeration + authoritative destroy + CLI fallback).**
-   - `providers/vastai.py:list_vastai_instances()` (returns `list[InstanceCandidate]`, empty list on API failure).
-   - `providers/vastai.py:VASTAI_ELIGIBLE_STATES` module constant (frozenset of states the destroy path can act on).
-   - `providers/vastai.py:build_vastai_cleanup_policy(config)` (wires `list_instances_fn` + `destroy_fn`).
-   - The factory wraps `list_vastai_instances` with the EXPLICITLY_DISABLED short-circuit.
-   - The factory's `_destroy` performs the eligibility check (`INELIGIBLE_STATE`) before delegating to `destroy_vastai_instance`.
+3. **Add Vast.ai runner + cleanup adapter.**
+   - `providers/vastai.py:VastaiProviderConfig` (frozen, with `__post_init__` invariants).
+   - `providers/vastai.py:VastaiRunner.from_config(canonical)` — preserves `ownership` and `credentials`.
+   - `VastaiRunner.__init__` adds `ownership: OwnershipPolicy | None` + `credentials: CredentialResolution | None` parameters; rejects simultaneous `ownership=` + `allowed_images=` with `ValueError`; `allowed_images` becomes a deprecated alias.
+   - `VastaiRunner.destroy_instance` is a single `destroy_vastai_instance(...)` adapter call (no v2 regression).
+   - `verify_instance_ownership(instance_id, *, ownership: OwnershipPolicy)` — replaces `_image_is_allowed`.
+   - `list_vastai_instances()` returns `list[InstanceCandidate]`, validates `instance_id` non-empty.
+   - `VASTAI_TERMINAL_STATES: frozenset[str]` module constant.
+   - `build_vastai_cleanup_policy(*, ownership: OwnershipPolicy, credentials: CredentialResolution) -> ProviderCleanupPolicy` — wires list + destroy callbacks.
    - Adapter tests:
-     - **disabled-before-enumeration**: config with `credentials=EXPLICITLY_DISABLED`; `policy.list_instances()` returns `[]` without invoking `vastai_cmd` (mock and assert `vastai_cmd` was not called).
-     - `AVAILABLE` path: `destroy_fn` calls `destroy_vastai_instance` with the loaded key; `verdict=DESTROYED` → `CleanupResult(verdict=DESTROYED)`.
-     - `ABSENT` path: `destroy_fn` falls through to CLI fallback (per v3 contract); `verdict=CLI_ATTEMPTED` → `CleanupResult(verdict=CLI_ATTEMPTED, error=...)`.
-     - `verdict=OWNERSHIP` translation → `CleanupResult(refusal=OWNERSHIP)`.
-     - `verdict=NO_CREDENTIALS` translation → `CleanupResult(refusal=NO_CREDENTIALS)`.
-     - `verdict=CREDENTIALS_DISABLED` translation → `CleanupResult(refusal=CREDENTIALS_DISABLED)`.
-     - `verdict=LEAKED` translation → `CleanupResult(verdict=LEAKED, error=...)`.
-     - `verdict=UNKNOWN` translation → `CleanupResult(verdict=UNKNOWN, error=...)`.
-     - `INELIGIBLE_STATE` path: candidate.state not in `VASTAI_ELIGIBLE_STATES` → `CleanupResult(refusal=INELIGIBLE_STATE, error=...)` without invoking `destroy_vastai_instance`.
-     - `list_vastai_instances()` returns `[]` on `RuntimeError` and `JSONDecodeError` (does not raise).
+     - EXPLICITLY_DISABLED: `list_instances()` returns `[]` without invoking `vastai_cmd`.
+     - ABSENT CLI fallback: v3 returns `NO_CREDENTIALS` → factory runs CLI ownership verification + CLI destroy → `CLI_ATTEMPTED` (not `DESTROYED`) on command success; `UNKNOWN` on command failure.
+     - AVAILABLE: v3 returns `DESTROYED` → `verdict=DESTROYED`.
+     - `verdict=LEAKED` / `verdict=UNKNOWN` translate correctly with `_describe(result)` diagnostic.
+     - `refusal=OWNERSHIP` / `NO_CREDENTIALS` / `CREDENTIALS_DISABLED` translate correctly.
+     - INELIGIBLE_STATE: candidate.state in `VASTAI_TERMINAL_STATES` → `refusal=INELIGIBLE_STATE`.
+     - PROVIDER_MISMATCH: handled by the policy's `destroy()` method, not the factory.
+     - `list_vastai_instances()` skips records with empty `instance_id`.
 
 4. **Add orchestrator support behind a fail-closed compatibility path.**
    - `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required).
-   - `_sweep_zombies` becomes policy-driven (the v4.3 code shape above).
+   - `_sweep_zombies` is policy-driven; logs every non-`DESTROYED` outcome at severity matching operational impact.
    - Orchestrator tests:
-     - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once.
-     - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate.
-     - `_sweep_zombies` counts only `verdict=DESTROYED` outcomes.
-     - `_sweep_zombies` logs `CLI_ATTEMPTED`, `LEAKED`, `UNKNOWN`, and every refusal distinctly.
-     - `_sweep_zombies` continues on `destroy_fn` exceptions (they return `verdict=UNKNOWN`).
-     - `_sweep_zombies` does NOT branch on `Provider` (verified by `inspect.getsource` — `batch.py` should not contain `from vastai_gpu_runner.providers.vastai import` outside the docstring).
+     - Severity logging: `LEAKED` = `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` = `WARNING`, refusals = `INFO` (verified with `caplog`).
+     - `_sweep_zombies` continues on `destroy_fn` exceptions (they return `verdict=UNKNOWN` with `type(exc).__name__: exc`).
+     - `_sweep_zombies` does NOT import provider modules (verified by `inspect.getsource`).
 
 5. **Update every composition root, subclass, and existing CLI command.**
-   - `cli.py:batch` (composition root): build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy`.
-   - `cli.py:cleanup` (existing CLI command): migrate to use `build_vastai_cleanup_policy` + `policy.list_instances()` + `policy.destroy()`. No more direct `vastai_cmd(["show", "instances", "--raw"])` parsing.
-   - `cli.py:instances` (existing CLI command): migrate to use `list_vastai_instances()` for the table. The `--allowed-images` flag is preserved as canonical; `--owned-images` is added as a documented alias (back-compat for any external scripts that already use `--owned-images`).
-   - `BatchOrchestrator` subclasses (consumer code): existing `BatchOrchestrator(...)` calls now require `cleanup_policy`. Update each subclass's composition.
-   - Test fixtures and conftest: `VastaiProviderConfig` factory fixture for tests.
+   - `cli.py:batch`: build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy(ownership, credentials)`.
+   - `cli.py:cleanup`: build `OwnershipPolicy` and `CredentialResolution` directly (no `VastaiProviderConfig`), pass to `build_vastai_cleanup_policy`.
+   - `cli.py:instances`: use `list_vastai_instances()` for the table. `--allowed-images` canonical, `--owned-images` alias.
+   - `BatchOrchestrator` subclasses: update composition to supply `cleanup_policy`.
+   - Test fixtures: `VastaiProviderConfig` + `OwnershipPolicy` + `CredentialResolution` factory fixtures.
 
 6. **Add integration tests.**
-   - `tests/integration/test_cleanup_policy_integration.py` (or equivalent):
-     - **disabled-before-enumeration**: config with `credentials=EXPLICITLY_DISABLED`; `policy.list_instances()` returns `[]`; `vastai_cmd` was not called (verified by mock call count).
-     - **absent-credential CLI fallback**: config with `credentials=ABSENT`; `policy.destroy(candidate)` falls through to CLI fallback path; the v3 `destroy_vastai_instance` is invoked with `credentials=None` (the CLI fallback path); `verdict=CLI_ATTEMPTED` translates to `CleanupResult(verdict=CLI_ATTEMPTED, error=...)`.
-     - **empty ownership set**: config with `ownership=OwnershipPolicy(owned_images=frozenset())`; `policy.destroy(candidate)` returns `OWNERSHIP` for every candidate (fail-closed).
-     - **provider mismatch**: candidate with `provider=Provider.RUNPOD` passed to a `Provider.VASTAI` policy; returns `PROVIDER_MISMATCH` with the operator-friendly diagnostic.
-     - **enumeration failure**: `list_vastai_instances()` raises on `RuntimeError`; `policy.list_instances()` returns `[]` (the policy catches the exception).
-     - **ineligible state**: candidate with `state="destroyed"` passed to the Vast.ai policy; returns `INELIGIBLE_STATE` without invoking `destroy_vastai_instance`.
-     - **non-DESTROYED logging**: orchestrator logs `CLI_ATTEMPTED`, `LEAKED`, `UNKNOWN`, and every refusal distinctly (verified by `caplog`).
+   - `tests/integration/test_cleanup_policy_integration.py`:
+     - **disabled-before-enumeration**: `credentials=EXPLICITLY_DISABLED` → `policy.list_instances()` returns `[]`; `vastai_cmd` was not called (verified by mock call count).
+     - **absent-credential CLI fallback**: `credentials=ABSENT` → `policy.destroy(candidate)` returns `verdict=CLI_ATTEMPTED` (NOT `DESTROYED`); the canonical `ABSENT` resolution was passed to the REST adapter (NOT `None`).
+     - **empty ownership set**: `ownership=OwnershipPolicy(owned_images=frozenset())` → `verdict=...` → `OWNERSHIP` (fail-closed).
+     - **provider mismatch**: candidate `Provider.RUNPOD` to a Vast.ai policy → `PROVIDER_MISMATCH` with operator-friendly diagnostic.
+     - **enumeration failure**: `list_vastai_instances()` raises → `policy.list_instances()` returns `[]`.
+     - **ineligible state**: candidate `state="destroyed"` → `INELIGIBLE_STATE` without invoking `destroy_vastai_instance`.
+     - **severity logging**: orchestrator logs `LEAKED` at `ERROR`, `UNKNOWN` at `WARNING`, refusals at `INFO` (verified with `caplog`).
+     - **non-empty error from empty exception**: `raise RuntimeError()` (no message) → orchestrator logs with non-empty error containing `RuntimeError: `.
+     - **empty instance_id in enumeration**: malformed Vast.ai record skipped, not passed to destroy.
 
 7. **Delete legacy sweep + duplicated helpers after a repository-wide caller audit.**
-   - `audit_caller_sites.sh` (run before the deletion): grep for any external caller of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use). Update external callers.
-   - Delete `orchestrator.sweep_zombie_instances` (already deferred to v3; v4.3 reaffirms).
+   - `audit_caller_sites.sh` (run before deletion): grep for external callers of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use), `providers.vastai._image_is_allowed`. Update external callers.
+   - Delete `orchestrator.sweep_zombie_instances` (v3 deferral reaffirmed).
    - Delete `orchestrator.load_vastai_api_key` (v3 deferral reaffirmed).
-   - Delete `providers/vastai.py:_image_is_allowed` (replaced by `OwnershipPolicy.matches()`).
+   - Delete `providers/vastai.py:_image_is_allowed`.
    - Delete direct `vastai_cmd(["show", "instances", "--raw"])` parsing in `cli.py:cleanup` and `cli.py:instances`.
-   - Update `tests/test_orchestrator.py` and `tests/test_batch.py` to mock `cleanup_policy.list_instances` and `cleanup_policy.destroy` instead of `sweep_zombie_instances`.
+   - Update `tests/test_orchestrator.py` and `tests/test_batch.py` to mock `cleanup_policy.list_instances` and `cleanup_policy.destroy`.
 
 ## Test plan
 
-- `tests/test_cleanup_policy.py` — unit tests:
-  - `_repository`:
-    - `myorg/app:1.0` → `myorg/app`
-    - `myorg/app:latest` → `myorg/app`
-    - `myorg/app@sha256:abc...` → `myorg/app` (digest stripped)
-    - `ubuntu:22.04` → `ubuntu` (no slash)
-    - `registry:5000/myorg/app:1.0` → `registry:5000/myorg/app` (registry preserved)
-    - `registry-malicious/myorg/app:1.0` → `registry-malicious/myorg/app`
-    - `myorg/app:1.0:malicious` → `""` (malformed multi-tag)
-    - `myorg/app@sha1:abc@sha256:def` → `""` (malformed multi-digest)
-    - `""` → `""` (empty)
-    - `"   "` → `""` (whitespace only)
-  - `OwnershipPolicy.matches`:
-    - `None` ownership: every image matches (including the empty string and malformed references)
-    - Non-empty set: exact reference matches
-    - Non-empty set: tag-insensitive repository matches (`:1.0` and `:latest` both match)
-    - Non-empty set: sha256 digest matches by repository
-    - Non-empty set: different registry prefix does NOT match
-    - Non-empty set: image `myorg/app:1.0` does NOT match `myorg/app-malicious:latest`
-    - Non-empty set: `registry:5000/myorg/app:1.0` does NOT match `registry-malicious/myorg/app:1.0`
-    - Empty set: no image matches (fail-closed), including for the empty string and malformed references
-    - `_normalised` is precomputed and frozen: `matches` is O(1)
-  - `ProviderCleanupPolicy.list_instances`:
-    - Returns the wired list
-    - Catches and returns `[]` on `list_instances_fn` exception
-  - `ProviderCleanupPolicy.destroy`:
-    - Provider mismatch returns `PROVIDER_MISMATCH` with the operator-friendly error
-    - Catches `destroy_fn` exceptions and returns `CleanupResult(verdict=UNKNOWN, error=...)`
-    - Delegates to `destroy_fn` on the happy path
-  - `CleanupResult` invariants:
-    - `verdict=DESTROYED` + non-empty `error` raises `ValueError`
-    - `verdict=CLI_ATTEMPTED` + empty `error` raises `ValueError`
-    - `refusal=...` + empty `error` raises `ValueError`
-    - Both `verdict` and `refusal` set raises `ValueError`
-    - Neither `verdict` nor `refusal` set raises `ValueError`
-  - `VastaiProviderConfig` invariants:
-    - Empty `docker_image` raises `ValueError`
-    - Whitespace-only `docker_image` raises `ValueError`
-    - `docker_image` not in `owned_images` raises `ValueError`
-    - `docker_image` in `owned_images` is valid
-    - `ownership.owned_images is None` (disabled) accepts any `docker_image`
-    - `from_env(docker_image="")` raises `ValueError` (explicit empty is not None)
-    - `from_env(docker_image=None)` returns the default image
-- `tests/test_providers_vastai.py` — adapter tests:
-  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig` (constructor parity)
-  - `VastaiRunner(allowed_images=frozenset({img}))` (deprecated path) emits `DeprecationWarning` and builds an equivalent `OwnershipPolicy`
-  - `verify_instance_ownership` uses `OwnershipPolicy.matches()`
-  - `list_vastai_instances` returns `list[InstanceCandidate]` with `gpu_model` + `cost_per_hour` populated
-  - `list_vastai_instances` returns `[]` on API error (does not raise)
-  - `build_vastai_cleanup_policy` wires the v3 adapter correctly (all 4 verdicts, all 3 refusals, `INELIGIBLE_STATE`, `PROVIDER_MISMATCH`, EXPLICITLY_DISABLED short-circuit)
-- `tests/test_batch.py` — orchestrator wiring:
-  - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once
-  - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate
-  - `_sweep_zombies` counts only `verdict=DESTROYED` outcomes
-  - `_sweep_zombies` logs `CLI_ATTEMPTED`, `LEAKED`, `UNKNOWN`, and every refusal distinctly (`caplog`)
-  - `_sweep_zombies` continues on `destroy_fn` exceptions
-  - `_sweep_zombies` does NOT import provider modules (verified by `inspect.getsource`)
-- `tests/integration/test_cleanup_policy_integration.py` — integration tests (seven scenarios from step 6 above).
-- Existing tests for `verify_instance_ownership` and `VastaiRunner.destroy_instance` are updated to use `OwnershipPolicy` (the v4 amendment).
+- `tests/test_cleanup_policy.py`:
+  - `_repository`: 13+ cases (digest, registry ports, malformed, empty, whitespace).
+  - `OwnershipPolicy.matches`: reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets, malformed reference rejection.
+  - `OwnershipPolicy._normalised`: declared field; precomputed in `__post_init__`; `matches` is O(1) per call.
+  - `ProviderCleanupPolicy.list_instances`: returns wired list; catches and returns `[]` on exception.
+  - `ProviderCleanupPolicy.destroy`: provider mismatch returns `PROVIDER_MISMATCH`; catches `destroy_fn` exceptions with `f"{type(exc).__name__}: {exc}"` (non-empty even for `RuntimeError()` with no message).
+  - `CleanupResult` invariants: 5 cases (verdict/refusal exclusivity, error non-empty on non-DESTROYED, error empty on DESTROYED).
+  - `InstanceCandidate.__post_init__`: empty `instance_id` raises; whitespace-only `instance_id` raises.
+- `tests/test_providers_vastai.py`:
+  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig` (constructor parity).
+  - `VastaiRunner(allowed_images=frozenset({img}))` (deprecated) emits `DeprecationWarning` + builds equivalent `OwnershipPolicy`.
+  - Simultaneous `ownership=` and `allowed_images=` raises `ValueError`.
+  - `verify_instance_ownership` uses `OwnershipPolicy.matches()`.
+  - `list_vastai_instances` returns `list[InstanceCandidate]` with `gpu_model` + `cost_per_hour` populated; skips records with empty `instance_id`; returns `[]` on API error.
+  - `build_vastai_cleanup_policy(*, ownership, credentials)`:
+    - EXPLICITLY_DISABLED list: returns `[]` without `vastai_cmd`.
+    - ABSENT destroy: factory intercepts `NO_CREDENTIALS` → CLI ownership verify → CLI destroy → `CLI_ATTEMPTED` (success) or `UNKNOWN` (failure).
+    - AVAILABLE destroy: v3 DESTROYED → `verdict=DESTROYED`.
+    - LEAKED / UNKNOWN translate with `_describe(result)` diagnostic.
+    - OWNERSHIP / NO_CREDENTIALS / CREDENTIALS_DISABLED translate correctly.
+    - INELIGIBLE_STATE for `state in VASTAI_TERMINAL_STATES` or empty state.
+- `tests/test_batch.py`:
+  - `_sweep_zombies` calls `cleanup_policy.list_instances()` exactly once.
+  - `_sweep_zombies` calls `cleanup_policy.destroy(candidate)` for every label-matching, untracked candidate.
+  - `_sweep_zombies` counts only `verdict=DESTROYED` outcomes.
+  - `_sweep_zombies` logs `LEAKED` at `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` at `WARNING`, refusals at `INFO` (`caplog`).
+  - `_sweep_zombies` continues on `destroy_fn` exceptions.
+  - `_sweep_zombies` does NOT import provider modules (`inspect.getsource`).
+- `tests/integration/test_cleanup_policy_integration.py` — 9 scenarios from step 6 above.
 
 ## Backwards compatibility
 
 The `VastaiRunner.__init__(allowed_images=..., docker_image=..., ...)`
-constructor is preserved as a deprecated back-compat path. Existing
-callers (scripts, unit tests, third-party consumers) that build the
-runner by hand keep working but emit a `DeprecationWarning`. The
-CLI's new `batch` subcommand uses `from_config`; the old programmatic
-path requires a `cleanup_policy` to be supplied.
+constructor is preserved as a deprecated back-compat path (emits
+`DeprecationWarning`). The CLI's new `batch` subcommand uses
+`from_config`; the old programmatic path requires a `cleanup_policy`
+to be supplied.
 
 The `orchestrator.py:sweep_zombie_instances` function is deleted in
-v4 step 7. The v3 implementation already migrated its callers
-through the destroy protocol; v4's policy-driven sweep removes the
-last direct caller. Any external code that imported
-`sweep_zombie_instances` directly must be updated to construct a
-`ProviderCleanupPolicy` and call `policy.destroy(candidate)`.
+v4 step 7. External callers must construct a `ProviderCleanupPolicy`
+and call `policy.destroy(candidate)`.
 
 The `cli.py:cleanup` and `cli.py:instances` commands are refactored
 in v4 step 5. The `--allowed-images` flag is preserved as canonical;
 `--owned-images` is added as a documented alias. The rename is
-deferred to a separate CLI compatibility change (no removal of
-`--allowed-images` in this PR).
+deferred to a separate CLI compatibility change.
 
 ## Out of scope
 
-- **RunPod adapter.** The `ProviderCleanupPolicy` interface is
-  provider-agnostic, but the `build_runpod_cleanup_policy` factory
-  is omitted from this doc — it lands with the RunPod adapter
-  (roadmap item 2). The factory shape is defined by the
-  `ProviderCleanupPolicy` interface; the orchestrator's wiring is
+- **RunPod adapter.** The factory ships when the RunPod adapter
+  ships (roadmap item 2). The `ProviderCleanupPolicy` interface is
   provider-agnostic from day one.
-- **Hostile detection.** The v4 first draft had a `hostile_check`
-  boolean + threshold; the 5th-pass review flagged it as
-  semantically redundant. The 6th-pass review reaffirmed the
-  removal. Hostile detection is deferred to a separate audit
-  stage that emits alerts without changing the destroy decision.
-- **Dispute webhook.** The dispute workflow is future work.
-  YAGNI for now.
-- **Bulk-destroy optimisation.** The v4 sweep destroys one
-  candidate at a time. A bulk path is a future optimisation
-  (YAGNI for now; the per-candidate API call is the safe
-  default).
-- **Cross-provider zombie sweep.** A single orchestrator
-  currently supports one `cleanup_policy`. A multi-policy
-  orchestrator is a future design (the v4 on-by-one design is
-  simpler and covers the current use case).
+- **Hostile detection.** Removed in the v4 second-pass review.
+  Hostile detection is deferred to a separate audit stage that
+  emits alerts without changing the destroy decision.
+- **Dispute webhook.** Future work.
+- **Bulk-destroy optimisation.** YAGNI for now.
+- **Cross-provider zombie sweep.** A single orchestrator supports
+  one `cleanup_policy`. Multi-policy is future design.
 
 ## Review process
 
-This is the third review pass on the v4 architecture. The first
-draft was rejected with 5 BLOCKERs and 7 CONCERNs. The second draft
-was rejected with 7 BLOCKERs, 2 CONCERNs, and 3 NITs. This third
+This is the fourth review pass on the v4 architecture. The first
+draft was rejected with 5 BLOCKERs + 7 CONCERNs. The second draft
+was rejected with 7 BLOCKERs + 2 CONCERNs + 3 NITs. The third draft
+was rejected with 6 BLOCKERs + 4 CONCERNs + 2 NITs. This fourth
 draft addresses every finding.
 
-The third review prompt for ChatGPT-with-GitHub-plugin:
+The fourth review prompt for ChatGPT-with-GitHub-plugin:
 
 > Review the v4 architecture design at PR #22 (file:
 > docs/architecture-v4-cleanup-policy.md) against the v3 design at
 > docs/architecture-v3.md and the current code at
 > src/vastai_gpu_runner/{batch,orchestrator,runner,cli}.py and
 > src/vastai_gpu_runner/providers/vastai.py. The v4 design
-> resolves issue #19 (the ProviderCleanupPolicy follow-up).
+> resolves issue #19.
 >
-> The first draft was rejected with 5 BLOCKERs and 7 CONCERNs.
-> The second draft was rejected with 7 BLOCKERs, 2 CONCERNs, and
-> 3 NITs. Verify each finding is addressed:
+> The third draft was rejected with 6 BLOCKERs, 4 CONCERNs, and
+> 2 NITs. Verify each finding is addressed:
 >
-> 1. **BLOCKER 1 (_repository broken)**: confirm `_repository` now
->    strips digest, strips only the final tag separator (after
->    the last `/`), preserves registry and port, and rejects
->    malformed references.
-> 2. **BLOCKER 2 (runner/adapter don't consume OwnershipPolicy)**:
->    confirm both call `OwnershipPolicy.matches()` and the v3
->    `destroy_vastai_instance` accepts `ownership: OwnershipPolicy`.
-> 3. **BLOCKER 3 (v3 type names)**: confirm `CredentialState` (enum)
->    and `CredentialResolution` (dataclass with `state` and `key`)
->    are used.
-> 4. **BLOCKER 4 (EXPLICITLY_DISABLED before enumeration)**: confirm
->    the factory wraps `list_vastai_instances` and the integration
->    test asserts `vastai_cmd` is not called when credentials are
->    disabled.
-> 5. **BLOCKER 5 (CLI fallback + DestroyResult translation)**: confirm
->    the `_destroy` callback refuses EXPLICITLY_DISABLED without
->    provider calls, uses canonical API key for REST, runs CLI fallback
->    for ABSENT, returns `CLI_ATTEMPTED` after CLI command, translates
->    all four v3 verdicts and all three v3 refusals.
-> 6. **BLOCKER 6 (docker_image invariant)**: confirm empty or
->    whitespace-only `docker_image` raises `ValueError`.
-> 7. **BLOCKER 7 (undefined names)**: confirm `cleanup_policy.py`
->    imports `logging` and `cli.py` imports `OwnershipPolicy`.
-> 8. **CONCERN 8 (CleanupResult invariants)**: confirm `verdict |
->    refusal` is mutually exclusive and non-DESTROYED outcomes have
->    non-empty `error`.
-> 9. **CONCERN 9 (authoritative eligibility)**: confirm the factory's
->    `_destroy` checks `candidate.state not in VASTAI_ELIGIBLE_STATES`
->    and returns `INELIGIBLE_STATE`.
-> 10. **CONCERN 10 (InstanceCandidate fields)**: confirm
->     `gpu_model`, `cost_per_hour`, `ownership_key` are added.
-> 11. **CONCERN 11 (CLI flag rename)**: confirm `--allowed-images`
->     is preserved as canonical and `--owned-images` is an alias.
-> 12. **NIT 12 (provider assignment)**: confirm `provider=Provider.VASTAI`
->     is hardcoded (not derived from canonical.docker_image).
-> 13. **NIT 13 (provider-mismatch diagnostic)**: confirm the error
->     message includes the instance ID, actual provider, and
->     expected provider.
-> 14. **NIT 14 (stale prose)**: confirm all references to
->     `is_candidate`, "hostile classification", "verbidden", and
->     "the core module has provider-specific imports" are removed.
+> 1. **BLOCKER 1 (ABSENT CLI fallback)**: confirm the factory
+>    intercepts `DestroyRefusal.NO_CREDENTIALS` and runs CLI
+>    ownership verification + CLI destroy, returning
+>    `CLI_ATTEMPTED` (not `DESTROYED`) on command success.
+> 2. **BLOCKER 2 (v3 translation)**: confirm `CLI_ATTEMPTED` is
+>    NOT read from `DestroyVerdict`; confirm `_describe(result)`
+>    builds diagnostic text from `attempts`, `last_status_code`,
+>    `stop_error`, `verify_error`.
+> 3. **BLOCKER 3 (VastaiRunner delegation)**: confirm
+>    `VastaiRunner.destroy_instance` is a single
+>    `destroy_vastai_instance(...)` call; confirm `from_config`
+>    preserves both `ownership` and `credentials`; confirm
+>    simultaneous `ownership=` + `allowed_images=` raises
+>    `ValueError`.
+> 4. **BLOCKER 4 (non-empty catch error)**: confirm the catch
+>    uses `f"{type(exc).__name__}: {exc}"` so the error is
+>    always non-empty.
+> 5. **BLOCKER 5 (build_vastai_cleanup_policy direct args)**:
+>    confirm the factory takes `(*, ownership, credentials)`
+>    directly (no `VastaiProviderConfig` wrapper); confirm the
+>    cleanup CLI command does not construct a `VastaiProviderConfig`.
+> 6. **BLOCKER 6 (instance_id validation)**: confirm
+>    `list_vastai_instances` skips records with empty
+>    `instance_id`; confirm `InstanceCandidate.__post_init__`
+>    raises `ValueError` for empty or whitespace-only IDs.
+> 7. **CONCERN 7 (_normalised declared field)**: confirm
+>    `_normalised` is a `field(init=False, repr=False, compare=False)`.
+> 8. **CONCERN 8 (StrEnum for CredentialState)**: confirm
+>    `CredentialState(StrEnum)` (not plain `Enum`).
+> 9. **CONCERN 9 (negative allowlist)**: confirm
+>    `VASTAI_TERMINAL_STATES = frozenset({"destroyed"})` (skip
+>    only terminal states); confirm new states are processed.
+> 10. **CONCERN 10 (severity logging)**: confirm `LEAKED` =
+>     `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED`
+>     = `WARNING`, refusals = `INFO`.
+> 11. **NIT 11 (canonical flag)**: confirm `--allowed-images` is
+>     declared first in `typer.Option`; the Python parameter is
+>     `allowed_images`.
+> 12. **NIT 12 (is_candidate historical)**: confirm the historical
+>     change summary no longer mentions `is_candidate`.
 >
 > Additionally, identify any new BLOCKERs or CONCERNs introduced
-> by the third draft. Focus on:
-> - The `CleanupResult` verdict/refusal mapping in
->   `build_vastai_cleanup_policy._destroy`: is the translation
->   table complete and correct?
-> - The `_destroy` catch-all exception path: does it return
->   `verdict=UNKNOWN` or `refusal=...` consistently?
-> - The `ProviderCleanupPolicy.destroy` catch-all: same question.
-> - The VastaiRunner `allowed_images` deprecation: is the
->   `DeprecationWarning` emitted with the correct stacklevel?
-> - The `OwnershipPolicy._normalised` caching: is the
->   `object.__setattr__` pattern correct on a frozen dataclass
->   for an internal-cache field?
-> - The `VastaiProviderConfig.__post_init__` ordering: are the
->   `docker_image` non-empty check and the ownership-membership
->   check in the right order?
-> - The `build_vastai_cleanup_policy` EXPLICITLY_DISABLED short-
->   circuit: is the log message appropriate (warning vs. info)?
-> - The `_destroy` eligibility check: is `VASTAI_ELIGIBLE_STATES`
->   complete (covers all stuck/loading/created states)?
-> - The `_repository` helper: does it handle port-only registries
->   (`localhost:5000/myorg/app`) correctly?
+> by the fourth draft. Focus on:
+> - The factory's `_cli_fallback` ownership check: does it use
+>   `verify_instance_ownership` correctly? Does the failure path
+>   produce a structured refusal with non-empty error?
+> - The `_describe(result)` helper: does it handle all four
+>   structured fields correctly? Are empty fields handled
+>   gracefully?
+> - The `InstanceCandidate.__post_init__` invariant: does it
+>   correctly reject empty strings AND whitespace-only strings?
+> - The `OwnershipPolicy._normalised` declared field: does the
+>   `field(default=None)` correctly handle the case where
+>   `__post_init__` doesn't override it (None ownership)?
+> - The `build_vastai_cleanup_policy` signature change from
+>   `(canonical)` to `(*, ownership, credentials)`: is the
+>   batch command's extraction correct? Is the cleanup command's
+>   direct construction correct?
+> - The orchestrator's severity logging: does it correctly handle
+>   the `verdict=None` and `refusal=None` case (defensive)?
+> - The CLI's `--allowed-images` canonical declaration: does
+>   `typer.Option("--allowed-images", "--owned-images", ...)`
+>   accept both flags in the right order?
 >
 > Return a labeled list of findings. Each finding is one of:
 > BLOCKER (must fix before merge), CONCERN (should fix, but not

--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -1,0 +1,736 @@
+# Architecture v4 — ProviderCleanupPolicy
+
+This doc describes the **target architecture** for the layer above the v3
+belt-and-suspenders destroy refactor. It resolves [issue #19][i19] and
+defines the long-term shape for the zombie-sweep + ownership-guard
+policy.
+
+For the current-state architecture (today's code) see
+[`architecture.md`](architecture.md). For the v2 history see
+[`architecture-v2.md`](architecture-v2.md). For the v3 design (now
+merged but **not yet implemented**) see [`architecture-v3.md`](architecture-v3.md).
+The v3 doc's "Known limitation" section flagged this design as the
+next step.
+
+[i19]: https://github.com/Lambda-Biolab/vastai-gpu-runner/issues/19
+
+## What changes vs v3
+
+In one paragraph: the ownership-guard policy used by the zombie sweep
+moves from a `VastaiRunner.allowed_images` attribute (which the
+orchestrator can only read by introspecting a runner it has no business
+constructing) to a single, immutable `ProviderCleanupPolicy` object
+that is constructed once at boot time from the same canonical provider
+config used to build the runner factory. The runner factory and the
+cleanup policy now share **one** source of truth for "what counts as
+ours" and "what to do with not-ours" — no per-destroy runner
+construction, no drift between the `destroy_instance` ownership guard
+and the zombie-sweep ownership guard. The cleanup policy is
+provider-agnostic (a frozen dataclass with two methods); the
+provider-specific bits (Vast.ai image allowlist, RunPod template-id
+whitelist, etc.) live in adapter construction functions
+(`ProviderCleanupPolicy.from_vastai_config`,
+`ProviderCleanupPolicy.from_runpod_config`). The orchestrator's
+`_sweep_zombies` calls
+`cleanup_policy.is_candidate(snapshot)` and then
+`cleanup_policy.destroy(candidate)` — it never reads
+`allowed_images` directly and never calls a provider-specific destroy
+function.
+
+Diff vs v3 once v3 is implemented:
+
+- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen dataclass), `InstanceCandidate` (frozen dataclass), `CleanupRefusal` enum (`UNOWNED | NO_CREDENTIALS | CREDENTIALS_DISABLED`), `CleanupResult` (typed return), `from_vastai_config` / `from_runpod_config` constructors
+- **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` instead of `runner_factory + allowed_images` plumbing. The `runner_factory` is preserved (still needed for `_deploy_one`); only the ownership guard moves.
+- **~** `BatchOrchestrator._sweep_zombies` calls `cleanup_policy.is_candidate(candidate)` to filter, then `cleanup_policy.destroy(candidate)` to destroy. The orchestrator no longer imports `destroy_vastai_instance` — it knows the policy, not the provider.
+- **~** `VastaiRunner.__init__` keeps `allowed_images` for the `destroy_instance` ownership guard (it is the v3-daemon guard). The `from_vastai_config(cfg)` classmethod wraps the constructor so the policy and the runner share the same `allowed_images` value.
+- **+** `providers/vastai.py:list_vastai_instances()` — read-only enumeration (returns `list[InstanceCandidate]`). The orchestrator's `_sweep_zombies` uses this instead of inlining `vastai_cmd(["show", "instances", "--raw"])`.
+- **+** `providers/runpod.py` (separate tracking issue) — RunPod adapter consisting of `RunPodRunner` plus `list_runpod_instances()` plus `ProviderCleanupPolicy.from_runpod_config()`
+- **—** `BatchOrchestrator.__init__` no longer accepts `allowed_images` directly. The CLI now constructs the policy from the canonical config and passes it to the orchestrator.
+- **—** `BatchOrchestrator._sweep_zombies` no longer calls `sweep_zombie_instances` from `orchestrator.py` — the v3-routed destroy path is replaced by `cleanup_policy.destroy`. The `orchestrator.py:sweep_zombie_instances` function is **deleted** (the v3 implementation already migrated its callers through the destroy protocol).
+- **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) is reaffirmed; canonical credential loading lives in `providers/destroy_adapters/vastai.py` and the policy constructor reads from there.
+- **—** `tests/test_orchestrator.py:SweepZombieTests` — the existing tests mock `sweep_zombie_instances` directly; those mocks move to `cleanup_policy.is_candidate` / `cleanup_policy.destroy` mocks.
+
+## Module taxonomy
+
+The v4 doc adds one new module at the layer above the v3 destroy
+protocol. The `CloudRunner` ABC, `BatchOrchestrator`, `unit_lifecycle`,
+`providers/destroy`, and `providers/destroy_adapters/vastai` are
+unchanged in shape (v3 implementation is still a prerequisite).
+
+### New: `cleanup_policy` — owns the policy + the destroy-by-policy contract
+
+Owns: the policy dataclass (provider, repository image allowlist,
+hostile_check + threshold, optional dispute webhook), the candidate
+record (a snapshot of one enumerated instance), the refusal enum
+(safety-critical refusals before the destroy protocol runs), the
+typed result struct, the two adapter constructors. The
+`is_candidate` and `destroy` methods are the only public surface the
+orchestrator calls.
+
+Does **not** own: the destroy loop shape (lives in
+`providers/destroy`), the REST callbacks (live in the adapters), the
+API key loading (lives in the adapters), the enumeration logic
+(lives in `list_*_instances` per provider), the label-prefix filter
+(stays on the orchestrator — that's the per-batch scope, not the
+per-provider identity).
+
+## Layered design (v4)
+
+```
+┌─────────────────────────────────────────────────┐
+│  CLI (cli.py)                                   │  User-facing commands
+│    └── builds canonical ProviderConfig +        │
+│        ProviderCleanupPolicy once, threads      │
+│        both into the orchestrator               │
+├─────────────────────────────────────────────────┤
+│  BatchOrchestrator (batch.py)                   │  Phase loop + side-effect dispatchers
+│    └── accepts cleanup_policy (frozen)          │
+│    └── _sweep_zombies calls policy methods      │
+├─────────────────────────────────────────────────┤
+│  cleanup_policy (cleanup_policy.py)             │  NEW: policy + is_candidate + destroy
+│    └── from_vastai_config / from_runpod_config  │
+├─────────────────────────────────────────────────┤
+│  Providers' list_*_instances()                  │  NEW: read-only enumeration
+│    └── vastai: list_vastai_instances()          │
+│    └── runpod: list_runpod_instances() (later)  │
+├─────────────────────────────────────────────────┤
+│  unit_lifecycle (unit_lifecycle.py)             │  v3: decision tree, no side effects
+├─────────────────────────────────────────────────┤
+│  providers/destroy (providers/destroy.py)       │  v3: belt-and-suspenders protocol
+│    └── belt_and_suspenders(stop_fn, delete_fn,  │
+│        verify_fn, *, policy: DestroyPolicy)     │
+├─────────────────────────────────────────────────┤
+│  providers/destroy_adapters/vastai.py           │  v3: Vast.ai REST callbacks + policy
+│  providers/destroy_adapters/runpod.py           │  LATER: RunPod callbacks + policy
+├─────────────────────────────────────────────────┤
+│  CloudRunner (runner.py) ── Lane A ABC          │  Provider-agnostic lifecycle
+├──────────────┬──────────────┬───────────────────┤
+│ VastaiRunner │ RunPodRunner │ LocalRunner       │  Lane A implementations
+├──────────────┴──────────────┴───────────────────┤
+│  SSH (ssh.py)      — used by Vast.ai, RunPod    │
+│  subprocess        — used by Local              │
+└─────────────────────────────────────────────────┘
+```
+
+## `ProviderCleanupPolicy` shape
+
+Single public class, frozen dataclass, two methods, three refusal
+enum members, one typed result. Adapter constructors are classmethods.
+
+```python
+# src/vastai_gpu_runner/cleanup_policy.py
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Callable, Optional
+
+from vastai_gpu_runner.providers.destroy import (
+    DestroyPolicy,
+    DestroyResult,
+    DestroyRefusal,
+    belt_and_suspenders,
+)
+from vastai_gpu_runner.providers.destroy_adapters.vastai import (
+    VASTAI_POLICY,
+    destroy_vastai_instance,
+    read_vastai_api_key,
+)
+
+if TYPE_CHECKING:
+    from vastai_gpu_runner.types import Provider
+
+logger = logging.getLogger(__name__)
+
+
+class CleanupRefusal(Enum):
+    """Pre-protocol refusal reasons returned by ``cleanup_policy.destroy``.
+
+    The destroy protocol is *not* entered when a refusal is returned —
+    the policy has decided the candidate is not eligible for the
+    per-provider destroy path. The orchestrator logs the refusal and
+    skips the candidate.
+    """
+
+    UNOWNED = "unowned"          # image/template not in the allowlist
+    NO_CREDENTIALS = "no_credentials"  # no API key, no CLI fallback
+    CREDENTIALS_DISABLED = "credentials_disabled"  # API key explicitly empty
+
+
+@dataclass(frozen=True)
+class InstanceCandidate:
+    """Read-only snapshot of one instance returned by ``list_*_instances``.
+
+    Frozen dataclass so the policy can be stored alongside the
+    candidate in a temporary log without aliasing issues. Fields are
+    the union of what every provider can feasibly expose — providers
+    that do not have a field (e.g. RunPod has no ``image_uuid``)
+    leave it empty.
+    """
+
+    provider: "Provider"
+    instance_id: str
+    image_uuid: str          # Vast.ai: image tag; RunPod: template id
+    label: str
+    state: str               # raw provider state ("running", "stopped", ...)
+    started_at: float = 0.0  # unix epoch; 0 if unknown
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Outcome of ``cleanup_policy.destroy``.
+
+    Exactly one of ``destroyed`` (int) or ``refusal`` (CleanupRefusal)
+    is set. ``destroyed == 1`` means the destroy protocol succeeded;
+    ``destroyed == 0`` means the protocol ran but did not confirm
+    destruction (the daemon may have rejected the request, the
+    instance may have already been gone, etc.). A refusal is a
+    pre-protocol decision — the daemon was never contacted.
+    """
+
+    destroyed: int = 0
+    refusal: Optional[CleanupRefusal] = None
+    error: str = ""          # human-readable on protocol failure
+
+
+@dataclass(frozen=True)
+class ProviderCleanupPolicy:
+    """Per-provider cleanup contract.
+
+    Constructed once at boot time from the same canonical provider
+    config that builds the runner factory. Both the factory and the
+    policy read from the same frozen source — no per-destroy runner
+    construction, no drift between ``destroy_instance``'s ownership
+    guard and the zombie sweep's ownership guard.
+
+    Args:
+        provider: Which provider this policy applies to.
+        repository_image: The single image (or template id, for
+            RunPod) the project owns. ``None`` opts out of the
+            ownership guard (the policy still runs but accepts every
+            candidate). This is the sole configuration knob for
+            "what counts as ours."
+        hostile_check: Whether the policy should refuse to destroy
+            instances older than ``hostile_threshold_seconds`` that
+            are not in the allowlist. Default False (back-compat).
+        hostile_threshold_seconds: Threshold for the hostile check.
+        destroy_fn: Callable that takes an ``InstanceCandidate`` and
+            returns a ``CleanupResult``. Wired by the adapter
+            constructor. The orchestrator never calls this directly —
+            it calls ``policy.destroy(candidate)``.
+        candidate_filter: Callable that takes an ``InstanceCandidate``
+            and returns True if the candidate is eligible for the
+            destroy path. Default: always True. The label-prefix
+            filter is the orchestrator's responsibility, not the
+            policy's.
+
+    Why a ``destroy_fn`` callback instead of static protocol knowledge:
+    the v3 destroy protocol is generic (`stop_fn`, `delete_fn`,
+    `verify_fn` callbacks). The cleanup policy is the next layer up —
+    it owns the decision of "should we destroy this?" and delegates
+    the "how" to the v3 protocol via the adapter-supplied callback.
+    This keeps the v3 module policy-agnostic and the cleanup_policy
+    module agnostic of REST URLs.
+    """
+
+    provider: "Provider"
+    repository_image: Optional[str] = None
+    hostile_check: bool = False
+    hostile_threshold_seconds: int = 300
+    destroy_fn: Callable[[InstanceCandidate], CleanupResult] = field(
+        repr=False, compare=False
+    )
+    candidate_filter: Callable[[InstanceCandidate], bool] = field(
+        default=lambda _: True, repr=False, compare=False
+    )
+
+    def is_candidate(self, candidate: InstanceCandidate) -> bool:
+        """Return True if this candidate is eligible for the destroy path.
+
+        Applies ``candidate_filter`` first (cheap per-provider
+        rejection — e.g. ``state not in ("running", "stopped")``),
+        then the ownership guard (image/template matches
+        ``repository_image``), then the hostile check (if enabled
+        and the candidate is older than the threshold and is not
+        in the allowlist, refuse even if the filter passes).
+
+        The orchestrator calls this for every enumerated instance
+        before calling ``destroy``.
+        """
+        if not self.candidate_filter(candidate):
+            return False
+        if self.repository_image is None:
+            return True
+        if candidate.image_uuid == self.repository_image:
+            return True
+        return False
+
+    def destroy(self, candidate: InstanceCandidate) -> CleanupResult:
+        """Run the per-provider destroy on one candidate.
+
+        Handles the hostile-check refusal (when enabled), the
+        ownership refusal (when ``repository_image`` is set and the
+        candidate does not match), and delegates the actual
+        destroy protocol to ``destroy_fn``.
+
+        Never raises. The orchestrator must be able to log the
+        result and continue to the next candidate.
+        """
+        if self.hostile_check:
+            age = candidate.started_at and (
+                _now() - candidate.started_at
+            )
+            if age > self.hostile_threshold_seconds:
+                if not self.is_candidate(candidate):
+                    logger.warning(
+                        "Cleanup: REFUSED hostile candidate %s (age=%ds, image=%s)",
+                        candidate.instance_id,
+                        int(age),
+                        candidate.image_uuid,
+                    )
+                    return CleanupResult(
+                        refusal=CleanupRefusal.UNOWNED,
+                        error=f"hostile: older than {self.hostile_threshold_seconds}s",
+                    )
+        if self.repository_image is not None and not self.is_candidate(candidate):
+            return CleanupResult(
+                refusal=CleanupRefusal.UNOWNED,
+                error=f"image {candidate.image_uuid!r} not in {self.repository_image!r}",
+            )
+        try:
+            return self.destroy_fn(candidate)
+        except Exception as exc:
+            logger.warning(
+                "Cleanup: destroy_fn raised for %s: %s",
+                candidate.instance_id,
+                exc,
+            )
+            return CleanupResult(destroyed=0, error=str(exc))
+
+    # -- Adapter constructors --------------------------------------------
+
+    @classmethod
+    def from_vastai_config(
+        cls,
+        canonical_config: "VastaiProviderConfig",
+    ) -> "ProviderCleanupPolicy":
+        """Build a Vast.ai cleanup policy from the canonical config.
+
+        The canonical config (proposed shape: a frozen dataclass on
+        ``VastaiProviderConfig`` with ``allowed_images``,
+        ``api_key``, ``hostile_check``, ``hostile_threshold_seconds``)
+        is already the source of truth for the runner factory.
+        Reading from the same source guarantees the destroy
+        ownership guard and the runner's ownership guard cannot
+        drift.
+        """
+        from vastai_gpu_runner.providers.vastai import list_vastai_instances
+
+        def _destroy(candidate: InstanceCandidate) -> CleanupResult:
+            # Pre-protocol refusal: credentials explicitly disabled.
+            if canonical_config.api_key == "":
+                return CleanupResult(
+                    refusal=CleanupRefusal.CREDENTIALS_DISABLED,
+                    error="VASTAI_API_KEY explicitly empty",
+                )
+            # The v3 destroy_vastai_instance handles the ownership
+            # guard + the belt-and-suspenders protocol. Translate
+            # its DestroyResult into a CleanupResult.
+            result = destroy_vastai_instance(
+                candidate.instance_id,
+                allowed_images=frozenset({canonical_config.allowed_images})
+                if canonical_config.allowed_images else None,
+            )
+            if result.refusal == DestroyRefusal.OWNERSHIP:
+                return CleanupResult(
+                    refusal=CleanupRefusal.UNOWNED,
+                    error=result.error,
+                )
+            if result.refusal == DestroyRefusal.NO_CREDENTIALS:
+                return CleanupResult(
+                    refusal=CleanupRefusal.NO_CREDENTIALS,
+                    error=result.error,
+                )
+            if result.verdict == "destroyed":
+                return CleanupResult(destroyed=1)
+            return CleanupResult(destroyed=0, error=result.error)
+
+        def _candidate_filter(candidate: InstanceCandidate) -> bool:
+            return candidate.state in ("running", "stopped", "exited")
+
+        return cls(
+            provider=canonical_config.provider,
+            repository_image=canonical_config.allowed_images,
+            hostile_check=canonical_config.hostile_check,
+            hostile_threshold_seconds=canonical_config.hostile_threshold_seconds,
+            destroy_fn=_destroy,
+            candidate_filter=_candidate_filter,
+        )
+
+    @classmethod
+    def from_runpod_config(
+        cls,
+        canonical_config: "RunPodProviderConfig",
+    ) -> "ProviderCleanupPolicy":
+        """Build a RunPod cleanup policy from the canonical config.
+
+        Lands when the RunPod adapter ships (roadmap item 2). The
+        shape mirrors ``from_vastai_config`` so the orchestrator's
+        `_sweep_zombies` code is identical regardless of provider.
+        """
+        # Implementation deferred to the RunPod ship PR.
+        raise NotImplementedError(
+            "RunPod adapter lands in the RunPod ship PR (roadmap item 2)"
+        )
+
+
+def _now() -> float:
+    """Wall-clock now in unix seconds. Wrapped for test injection."""
+    import time
+    return time.time()
+```
+
+## `VastaiProviderConfig` shape
+
+The canonical config is a frozen dataclass that owns both the
+runner-side and the policy-side configuration. The runner factory
+and the cleanup policy constructor both read from it. This is the
+"share one canonical config" pattern the v3 5th-pass review
+recommended.
+
+```python
+# src/vastai_gpu_runner/providers/vastai.py (additions)
+@dataclass(frozen=True)
+class VastaiProviderConfig:
+    """Canonical Vast.ai configuration shared by runner factory + policy.
+
+    Both ``VastaiRunner.from_config(config)`` and
+    ``ProviderCleanupPolicy.from_vastai_config(config)`` read from
+    this. The same instance is passed to both at boot time, so the
+    ownership guard cannot drift between the runner's
+    ``destroy_instance`` and the policy's ``destroy`` method.
+    """
+
+    provider: Provider = Provider.VASTAI
+    allowed_images: Optional[str] = None  # single image — the project's
+    docker_image: str = DEFAULT_IMAGE
+    min_gpu_vram_mib: int = MIN_GPU_VRAM_MIB
+    setup_commands: tuple[str, ...] = ()
+    api_key: str = ""                     # read once at boot
+    hostile_check: bool = False
+    hostile_threshold_seconds: int = 300
+
+    @classmethod
+    def from_env(cls) -> "VastaiProviderConfig":
+        """Build from environment / config files.
+
+        Reads the canonical Vast.ai API key path
+        (``read_vastai_api_key`` from v3) and the project's
+        canonical image from env var
+        (``VASTAI_PROJECT_IMAGE``) — the image is a single
+        canonical value, not a set, because the project owns
+        one image per provider.
+        """
+        import os
+        from vastai_gpu_runner.providers.destroy_adapters.vastai import (
+            read_vastai_api_key,
+        )
+        return cls(api_key=read_vastai_api_key())
+
+
+class VastaiRunner(CloudRunner):
+    # ... existing constructor preserved for direct callers ...
+
+    @classmethod
+    def from_config(cls, config: VastaiProviderConfig) -> "VastaiRunner":
+        """Build a VastaiRunner from the canonical config.
+
+        Preserves the existing constructor as a back-compat path —
+        direct callers that build the runner by hand (unit tests,
+        scripts) keep working. The CLI uses this classmethod.
+        """
+        return cls(
+            allowed_images=frozenset({config.allowed_images})
+            if config.allowed_images else None,
+            docker_image=config.docker_image,
+            min_gpu_vram_mib=config.min_gpu_vram_mib,
+            setup_commands=list(config.setup_commands),
+        )
+```
+
+## `list_vastai_instances` shape
+
+The v3 design's destroy module owns the destroy protocol; the v4
+design adds the read-only enumeration helper that the orchestrator
+uses to discover zombies. The helper returns
+`list[InstanceCandidate]` so the orchestrator never touches raw
+provider dicts.
+
+```python
+# src/vastai_gpu_runner/providers/vastai.py (additions)
+def list_vastai_instances() -> list[InstanceCandidate]:
+    """Read-only enumeration of Vast.ai instances on this account.
+
+    Returns InstanceCandidate records (provider-agnostic DTOs) so the
+    orchestrator's zombie sweep does not have to parse Vast.ai's
+    JSON shape. A failure to enumerate returns an empty list — the
+    orchestrator's existing exception handling logs the failure and
+    continues.
+    """
+    from vastai_gpu_runner.cleanup_policy import InstanceCandidate
+    try:
+        raw = vastai_cmd(["show", "instances", "--raw"], timeout=15)
+        instances = json.loads(raw)
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        logger.warning("list_vastai_instances: enumeration failed: %s", exc)
+        return []
+    candidates: list[InstanceCandidate] = []
+    for inst in instances:
+        try:
+            candidates.append(
+                InstanceCandidate(
+                    provider=Provider.VASTAI,
+                    instance_id=str(inst.get("id", "")),
+                    image_uuid=str(inst.get("image_uuid", "")),
+                    label=str(inst.get("label", "")),
+                    state=str(inst.get("actual_status", "")),
+                    started_at=float(inst.get("start_date", 0.0) or 0.0),
+                )
+            )
+        except (TypeError, ValueError) as exc:
+            logger.debug("Skipping malformed instance: %s", exc)
+    return candidates
+```
+
+## Orchestrator wiring
+
+The orchestrator's `_sweep_zombies` becomes policy-driven. The
+provider-specific destroy call is gone; the orchestrator only knows
+the policy.
+
+```python
+# src/vastai_gpu_runner/batch.py (changes to _sweep_zombies)
+def _sweep_zombies(self) -> int:
+    """Destroy orphaned instances not tracked by live_runners.
+
+    Routes through the cleanup policy:
+    1. Enumerate instances via the provider's list_*_instances().
+    2. Filter by label prefix (orchestrator's per-batch scope).
+    3. Exclude tracked IDs (the existing semantics).
+    4. For each candidate, ask the policy if it's a candidate.
+    5. For each candidate, call policy.destroy(candidate).
+    6. Count destroyed == 1 outcomes.
+    """
+    with self._state_lock:
+        tracked_ids = {
+            entry[1].instance_id for entry in self._live_runners.values()
+        }
+    try:
+        candidates = self._cleanup_policy.list_provider_instances()
+    except Exception as exc:
+        logger.warning("Zombie sweep: enumeration failed: %s", exc)
+        return 0
+    killed = 0
+    for candidate in candidates:
+        if not candidate.label.startswith(self._label_prefix):
+            continue
+        if candidate.instance_id in tracked_ids:
+            continue
+        if not self._cleanup_policy.is_candidate(candidate):
+            continue
+        result = self._cleanup_policy.destroy(candidate)
+        if result.destroyed == 1:
+            killed += 1
+        elif result.refusal is not None:
+            logger.info(
+                "Zombie sweep: %s refused (%s): %s",
+                candidate.instance_id,
+                result.refusal.value,
+                result.error,
+            )
+    if killed:
+        logger.info("Zombie sweep: destroyed %d instance(s)", killed)
+    return killed
+```
+
+The orchestrator no longer imports `sweep_zombie_instances` from
+`orchestrator.py`. The orchestrator's `__init__` now requires
+`cleanup_policy: ProviderCleanupPolicy` and `runner_factory:
+RunnerFactory`. The `runner_factory` is preserved for the deploy
+path; only the ownership guard migrates.
+
+## CLI wiring
+
+The CLI is the one place that builds the canonical config and the
+runner factory. It threads the same config into the policy
+constructor.
+
+```python
+# src/vastai_gpu_runner/cli.py (new "batch" subcommand)
+@app.command()
+def batch(
+    label: Annotated[str, typer.Option("--label", "-l")] = ...,
+    image: Annotated[
+        str, typer.Option("--image", help="Canonical Docker image owned by this project")
+    ] = ...,
+    max_parallel: Annotated[int, typer.Option("--max-parallel", "-p")] = 8,
+    budget: Annotated[float, typer.Option("--budget")] = 0.0,
+) -> None:
+    """Run a batch of cloud GPU units under the user's project image."""
+    from vastai_gpu_runner.providers.vastai import (
+        VastaiProviderConfig,
+        VastaiRunner,
+    )
+    from vastai_gpu_runner.cleanup_policy import (
+        ProviderCleanupPolicy,
+    )
+
+    # Step 1: one canonical config. Frozen — immutable.
+    config = VastaiProviderConfig.from_env().__class__(
+        allowed_images=image,
+    )
+
+    # Step 2: runner factory reads from the same config.
+    runner_factory = lambda: VastaiRunner.from_config(config)  # noqa: E731
+
+    # Step 3: cleanup policy reads from the same config.
+    cleanup_policy = ProviderCleanupPolicy.from_vastai_config(config)
+
+    orch = MyOrchestrator(
+        runner_factory=runner_factory,
+        cleanup_policy=cleanup_policy,
+        label_prefix=label,
+        # ... other params ...
+    )
+    orch.run()
+```
+
+## Why Option B (canonical config) over Option A (per-runner `destroy_zombie`)
+
+The issue text pivoted to Option B as primary because Option A has
+a fundamental problem: a zombie candidate is **by definition** not
+in the live-runner map, so the orchestrator cannot "use the runner
+from the tuple" — there is no runner for an orphan. The orphan is
+discovered via the provider's list endpoint and the orchestrator
+never had a `CloudRunner` for it. Option A would need to either
+(a) resurrect the runner from the candidate (which requires the
+candidate to carry the deployment config — a heavier wire), or
+(b) run a factory per zombie (which is the bug the v3 5th-pass
+review flagged).
+
+Option B avoids both: the policy is the unit of work, the runner
+factory is a deployment-time construction, and the two never
+compete for the same role.
+
+## Migration checklist
+
+Seven steps. Each step is independently mergeable behind a
+feature flag, but the migration should land as one PR because the
+intermediate states are not stable (e.g. the orchestrator with no
+`cleanup_policy` is a regression). The PR is the v4 implementation.
+
+1. **Add `cleanup_policy.py` with `ProviderCleanupPolicy`, `InstanceCandidate`, `CleanupRefusal`, `CleanupResult`.** Includes the `from_vastai_config` constructor and the `is_candidate` / `destroy` methods. Unit tests for the policy itself (mock `destroy_fn`).
+2. **Add `VastaiProviderConfig` and `VastaiRunner.from_config` to `providers/vastai.py`.** Preserves the existing `VastaiRunner.__init__` constructor as a back-compat path. The new classmethod is the canonical entry point.
+3. **Add `list_vastai_instances()` to `providers/vastai.py`.** Returns `list[InstanceCandidate]`. Existing v3 styles for the JSON shape (parse `id`, `image_uuid`, `label`, `actual_status`, `start_date`).
+4. **Replace `BatchOrchestrator._sweep_zombies` with the policy-driven version.** The orchestrator imports `cleanup_policy.ProviderCleanupPolicy` and the new `list_vastai_instances` (when `provider == VASTAI`). The orchestrator's `__init__` drops the v2 shape and accepts `cleanup_policy`.
+5. **Update `cli.py` to build the canonical config and thread it into both the runner factory and the cleanup policy.** The CLI is the only place that constructs the policy at boot time.
+6. **Delete `orchestrator.py:sweep_zombie_instances`** (already deferred to v3's scope; v4 re-confirms the deletion). The v3 implementation already routed destroy through the v3 protocol; v4's policy-driven sweep removes the last direct caller.
+7. **Update `tests/test_orchestrator.py` and `tests/test_batch.py`** to mock `cleanup_policy.is_candidate` / `cleanup_policy.destroy` instead of `sweep_zombie_instances`. New `tests/test_cleanup_policy.py` for the policy unit tests.
+
+## Test plan
+
+- `tests/test_cleanup_policy.py` — unit tests for the policy:
+  - `is_candidate` returns True when `repository_image` is None
+  - `is_candidate` returns True when `image_uuid == repository_image`
+  - `is_candidate` returns False when `image_uuid != repository_image`
+  - `is_candidate` is False when `candidate_filter` returns False
+  - `destroy` returns `CleanupResult(destroyed=1)` on protocol success
+  - `destroy` returns `CleanupResult(refusal=UNOWNED)` when ownership check fails
+  - `destroy` returns `CleanupResult(refusal=CREDENTIALS_DISABLED)` when `api_key == ""`
+  - `destroy` returns `CleanupResult(destroyed=0, error=...)` when `destroy_fn` raises
+  - `destroy` returns `CleanupResult(refusal=UNOWNED, error="hostile: ...")` when hostile check fires
+  - `from_vastai_config` wires the Vast.ai adapter correctly
+  - Property-based: `is_candidate` is idempotent (calling it twice returns the same value)
+- `tests/test_providers_vastai.py` — additions for the canonical config:
+  - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig`
+  - `list_vastai_instances` returns `InstanceCandidate` records
+  - `list_vastai_instances` returns `[]` on API error (does not raise)
+- `tests/test_batch.py` — additions for the policy-driven sweep:
+  - `_sweep_zombies` calls `cleanup_policy.is_candidate` and `cleanup_policy.destroy`
+  - `_sweep_zombies` counts only `destroyed == 1` outcomes
+  - `_sweep_zombies` logs refusals
+  - `_sweep_zombies` continues on `destroy_fn` exceptions
+- Existing tests for `verify_instance_ownership` and `VastaiRunner.destroy_instance` are unchanged (the runner's ownership guard is preserved; only the policy owner changes).
+
+## Backwards compatibility
+
+The `VastaiRunner.__init__(allowed_images=..., docker_image=..., ...)`
+constructor is preserved. Existing callers (scripts, unit tests,
+third-party consumers) that build the runner by hand keep working.
+The CLI's new `batch` subcommand is the recommended path; the old
+programmatic path (`MyOrchestrator(runner_factory=...)`) is preserved
+when `cleanup_policy` is supplied alongside the factory.
+
+The `orchestrator.py:sweep_zombie_instances` function is deleted in
+v4 step 6. The v3 implementation already migrated its callers
+through the destroy protocol; v4's policy-driven sweep removes the
+last direct caller. Any external code that imported
+`sweep_zombie_instances` directly must be updated to construct a
+`ProviderCleanupPolicy` and call `policy.destroy(candidate)` per
+enumerated orphan.
+
+## Out of scope
+
+- **RunPod adapter implementation.** The `from_runpod_config`
+  constructor raises `NotImplementedError` until the RunPod ship
+  PR. The shape is defined here so the orchestrator wiring is
+  provider-agnostic from day one.
+- **Dispute webhook.** The `dispute_webhook` field is in the
+  optional future-proofing comments but not on the dataclass
+  (YAGNI). It lands when the dispute workflow is built.
+- **Bulk-destroy optimisation.** The v4 sweep destroys one
+  candidate at a time. A bulk path is a future optimisation
+  (YAGNI for now; the per-candidate API call is the safe
+  default).
+- **Cross-provider zombie sweep.** If a user runs both Vast.ai
+  and RunPod in the same batch, the v4 design supports one
+  `cleanup_policy` per orchestrator. A multi-policy orchestrator
+  is a future design (the v4 on-by-one design is simpler and
+  covers the current use case).
+
+## Review process
+
+This design is the v4 follow-up to the v3 architecture. The first
+review prompt for ChatGPT-with-GitHub-plugin will be:
+
+> Review the v4 architecture design at `docs/architecture-v4-cleanup-policy.md`
+> against the v3 design at `docs/architecture-v3.md` and the
+> current code at `src/vastai_gpu_runner/{batch,orchestrator,runner,cli}.py`
+> and `src/vastai_gpu_runner/providers/vastai.py`. The v4 design
+> resolves issue #19 (the ProviderCleanupPolicy follow-up). Focus
+> on: (1) the canonical-config pattern — does it actually prevent
+> the drift the v3 5th-pass review flagged? (2) the
+> `is_candidate` / `destroy` split — is the second method
+> redundant? (3) the
+> `cleanup_policy.py:ProviderCleanupPolicy` shape — is the frozen
+> dataclass + `destroy_fn` callback idiomatic, or should the
+> policy be split into a `CandidateFilter` + a `DestroyDispatcher`?
+> (4) the RunPod forward path — is `from_runpod_config` raising
+> `NotImplementedError` the right stub, or does it leak an
+> unimplemented state into the orchestrator's code path? (5) the
+> hostile-check semantics — is the threshold-based check the right
+> shape, or should hostile be a separate stage independent of
+> ownership?
+>
+> Return a labeled list of findings. Each finding is one of:
+> BLOCKER (must fix before merge), CONCERN (should fix, but not
+> blocking), or NIT (nice to have). For each finding, give the
+> exact line range, the issue, and the proposed fix. If the
+> design is acceptable as-is, say "DESIGN ACCEPTED" with a
+> one-line rationale.
+
+The iteration loop is the same as v3: paste the prompt into
+ChatGPT, paste the response back, apply the fixes, push the
+amended commit, repeat until the response is "DESIGN ACCEPTED" or
+all CONCERNs are resolved.

--- a/docs/architecture-v4-cleanup-policy.md
+++ b/docs/architecture-v4-cleanup-policy.md
@@ -14,6 +14,14 @@ next step. Issue #19's fifth-pass review recommended Option B
 (canonical config) over Option A (per-runner `destroy_zombie`) — the
 v4 design implements Option B.
 
+The v4 design **does not redefine any v3 types**. The v3 module
+`providers/destroy.py` is a hard prerequisite: it owns
+`DestroyVerdict`, `DestroyRefusal`, `DestroyResult`, `VerifyVerdict`,
+`VerifyResult`, `DestroyPolicy`, the callback protocols, and
+`belt_and_suspenders`. The v4 implementation either lands v3 first
+or merges v3 as part of the same PR. The v4 doc references v3
+verbatim and only amends `destroy_vastai_instance`'s signature.
+
 [i19]: https://github.com/Lambda-Biolab/vastai-gpu-runner/issues/19
 
 ## What changes vs v3
@@ -43,23 +51,26 @@ matching its operational impact (`LEAKED` = `ERROR`, unexpected
 `CREDENTIALS_DISABLED` = `WARNING`, refusals = `INFO`). The
 `VastaiRunner.destroy_instance` method delegates entirely to the v3
 adapter (no v2 regression) and logs the typed `DestroyResult` for
-non-`DESTROYED` outcomes.
+non-`DESTROYED` outcomes. The `cli.py:instances` command's "Owned"
+column uses `OwnershipPolicy.matches()` (the v2 substring/prefix
+match is removed).
 
 Diff vs v3 once v3 is implemented:
 
-- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, non-empty `instance_id` invariant), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`, declared `_normalised` cache field). The `ProviderCleanupPolicy.destroy()` method validates the `destroy_fn` callback return type (cannot return `None` or a non-`CleanupResult`).
-- **+** `src/vastai_gpu_runner/providers/destroy.py` — `DestroyVerdict`, `DestroyRefusal`, `DestroyResult` (v3 verbatim — the canonical destroy types live here, not in the adapter).
-- **~** `src/vastai_gpu_runner/providers/destroy_adapters/vastai.py` — only `CredentialState`, `CredentialResolution`, `read_vastai_api_key()` (v3 env-first + fail-closed semantics), and the amended `destroy_vastai_instance()` signature (`ownership: OwnershipPolicy`, `credentials: CredentialResolution | None`). The destroy types are imported from `providers/destroy.py`, not redefined.
+- **+** `src/vastai_gpu_runner/cleanup_policy.py` — `ProviderCleanupPolicy` (frozen, `kw_only`), `InstanceCandidate` (frozen, non-empty `instance_id` invariant), `CleanupVerdict` enum (`DESTROYED | CLI_ATTEMPTED | LEAKED | UNKNOWN`), `CleanupRefusal` enum (`OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED | INELIGIBLE_STATE | PROVIDER_MISMATCH`), `CleanupResult` (typed return with `__post_init__` invariants), `OwnershipPolicy` (frozen, `matches(image_ref)`, declared `_normalised` cache field, narrowed for strict type checking).
 - **+** `src/vastai_gpu_runner/providers/vastai.py:VastaiProviderConfig` (frozen, owns `ownership: OwnershipPolicy`, `credentials: CredentialResolution`, `docker_image`, etc.)
 - **+** `src/vastai_gpu_runner/providers/vastai.py:build_vastai_cleanup_policy(*, ownership, credentials)` — provider-owned factory that takes the two canonical objects directly (no config wrapper)
 - **+** `src/vastai_gpu_runner/providers/vastai.py:list_vastai_instances()` — read-only enumeration returning `list[InstanceCandidate]`, validates `instance_id` is a non-`None` non-empty string
+- **+** `src/vastai_gpu_runner/providers/vastai.py:_describe_destroy_result(result)` — single shared diagnostic helper, used by both the runner and the factory; includes `verdict` + `refusal` in the output
+- **~** `providers/destroy_adapters/vastai.py:destroy_vastai_instance` accepts `ownership: OwnershipPolicy` directly (replaces `allowed_images: frozenset[str]`); accepts `credentials: CredentialResolution | None` (defaults to `read_vastai_api_key()` for back-compat direct callers). The v3 implementation must adopt this signature.
+- **~** `providers/destroy_adapters/vastai.py:read_vastai_api_key()` — v3 env-first + fail-closed semantics (env var first, then file fallback with warning + `ABSENT` on blank/unreadable file)
 - **~** `VastaiRunner.__init__` accepts `ownership: OwnershipPolicy | None` and `credentials: CredentialResolution | None`; rejects simultaneous `ownership=` and deprecated `allowed_images=` with `ValueError`.
 - **~** `VastaiRunner.from_config(config)` preserves both `canonical.ownership` and `canonical.credentials`.
 - **~** `VastaiRunner.destroy_instance` delegates entirely to `destroy_vastai_instance(...)` — no v2-style inline ownership pre-check, no inline REST stop/delete/verify. Returns `bool` from the typed adapter result, logging the typed `DestroyResult` for non-`DESTROYED` outcomes.
 - **~** `BatchOrchestrator.__init__` accepts `cleanup_policy: ProviderCleanupPolicy` (required). The orchestrator calls `policy.list_instances()` and `policy.destroy(candidate)` — never branches on `Provider`, never imports provider modules.
 - **~** `BatchOrchestrator._sweep_zombies` is policy-driven end-to-end. The label-prefix filter and tracked-id exclusion stay on the orchestrator. Every other decision is delegated to `policy.destroy()`. The orchestrator logs every non-`DESTROYED` outcome at severity matching operational impact.
-- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new API. The `--allowed-images` flag is the canonical primary; `--owned-images` is an alias. Empty `--allowed-images ""` is **fail-closed** (empty set rejects every image), not opt-out.
-- **—** `orchestrator.py:sweep_zombie_instances` (v3 deletion) — reaffirmed. The v4 implementation removes the last direct caller.
+- **~** `cli.py:cleanup` and `cli.py:instances` — refactored to use the new API. The `--allowed-images` flag is the canonical primary; `--owned-images` is an alias. Empty `--allowed-images ""` is **fail-closed** (empty set rejects every image), not opt-out. The `instances` command's "Owned" column uses `OwnershipPolicy.matches()` (the v2 unsafe substring/prefix match is removed).
+- **—** `orchestrator.py:sweep_zombie_instances` (v3 deletion) — reaffirmed.
 - **—** `orchestrator.py:load_vastai_api_key` (v3 deletion) — reaffirmed.
 - **—** `providers/vastai.py:_image_is_allowed` (raw set check) — replaced by `OwnershipPolicy.matches()`.
 - **~** `tests/test_orchestrator.py` and `tests/test_batch.py` — mock `cleanup_policy.list_instances()` and `cleanup_policy.destroy()` instead of `sweep_zombie_instances`.
@@ -86,51 +97,49 @@ in `VastaiProviderConfig` (because the runner also needs
 `docker_image`, `setup_commands`, etc.); the cleanup-policy factory
 takes them directly.
 
-## What changes vs the v4 first + second + third + fourth drafts
+## What changes vs the v4 first + second + third + fourth + fifth drafts
 
 The first draft was rejected with 5 BLOCKERs and 7 CONCERNs. The
 second draft was rejected with 7 BLOCKERs, 2 CONCERNs, and 3 NITs.
 The third draft was rejected with 6 BLOCKERs, 4 CONCERNs, and 2 NITs.
-The fourth draft was rejected with 5 BLOCKERs and 3 CONCERNs. This
-fifth draft addresses every finding.
+The fourth draft was rejected with 5 BLOCKERs and 3 CONCERNs. The
+fifth draft was rejected with 2 BLOCKERs, 2 CONCERNs, and 1 NIT.
+This sixth draft addresses every finding.
 
-### Applied from the 8th-pass review (this pass)
+### Applied from the 9th-pass review (this pass)
 
-- **Module ownership corrected.** `DestroyVerdict` / `DestroyRefusal` / `DestroyResult` are now defined in `providers/destroy.py` (v3 verbatim) and *imported* by the adapter and the runner — not redefined in the adapter. The runner's `providers/vastai.py` imports them from `providers.destroy`, not from `providers.destroy_adapters.vastai`. `vastai_cmd` and `verify_instance_ownership` are local to `providers/vastai.py` (no import). (BLOCKER 1)
-- **`read_vastai_api_key` rewritten per v3 env-first contract.** Inspects `VASTAI_API_KEY` env var first (present-but-empty → `EXPLICITLY_DISABLED`, present-and-non-empty → `AVAILABLE`); falls back to credential files; blank/unreadable files log a warning and continue as `ABSENT` (NOT disabled); catches `OSError`. (BLOCKER 2)
-- **`DestroyResult` types referenced from v3 verbatim.** The adapter block no longer defines `DestroyResult` / `DestroyVerdict` / `DestroyRefusal`. The v4 factory imports them from `providers.destroy`. Optional diagnostic fields with `None` defaults; invariants enforced in `__post_init__`: exactly one of verdict/refusal, no protocol context on refusals, ≥1 attempt on verdict outcomes. `_describe()` handles `None` fields gracefully. (BLOCKER 3)
-- **Empty `--allowed-images` is fail-closed.** The cleanup CLI distinguishes `None` (flag omitted → opt-out `OwnershipPolicy()`) from `""` (explicit empty → empty set `OwnershipPolicy(owned_images=frozenset())` → reject everything). Whitespace-only entries in comma-separated input are stripped. (BLOCKER 4)
-- **Null provider ID rejected.** `list_vastai_instances` validates `inst` is a dict, then explicitly checks `inst.get("id") is None` (catches `id: null` JSON which `str(None)` would convert to the literal `"None"`). Records with null/empty/whitespace IDs are skipped with a warning. (BLOCKER 5)
-- **`destroy_fn` return type validated.** `ProviderCleanupPolicy.destroy()` checks the callback's return is a `CleanupResult` instance; if not, returns `CleanupResult(verdict=UNKNOWN, error="destroy_fn returned invalid result type ...")` so the orchestrator never sees a non-`CleanupResult`. (CONCERN 6)
-- **Unexpected `NO_CREDENTIALS` escalated to WARNING.** If the factory's CLI fallback path is bypassed and `NO_CREDENTIALS` reaches the orchestrator, that means the orphan was not cleaned up. Bumped from INFO to WARNING. (CONCERN 7)
-- **`VastaiRunner.destroy_instance` logs the typed result.** The runner keeps the single adapter call but logs `DestroyResult` verdict/refusal + diagnostic context before returning `False`. No v2 inline destroy logic reintroduced. (CONCERN 8)
+- **Removed the v4 `providers/destroy.py` block.** The doc no longer claims to add or redefine `DestroyVerdict` / `DestroyRefusal` / `DestroyResult`. v3's `providers/destroy.py` is referenced as the authoritative source; the v4 migration checklist makes v3 implementation a hard prerequisite (either land v3 first or merge v3 as part of the same PR). (BLOCKER 2)
+- **`DestroyResult` not redefined.** The v4 doc references v3's `DestroyResult` verbatim — `attempts: int = 0`, `stop_error: str | None = None`, `last_status_code: int | None = None`, `verify_error: str | None = None`, with v3's invariants (`attempts == 0` for refusal, `attempts >= 1` for verdict, no protocol context on refusals). The v4 doc's diagnostic helper reads fields by name (order-independent). (BLOCKER 1)
+- **`_describe_destroy_result` consolidated and enriched.** Single shared helper in `providers/vastai.py`, used by both the runner and the factory. Output includes `verdict` and `refusal` (not just attempts + errors) so the fallback "unrecognised result" log exposes the actual typed outcome. (CONCERN 3)
+- **`cli.py:instances` migration expanded.** The migration step now requires `OwnershipPolicy` construction (with comma trimming like `cleanup`), `ownership.matches(candidate.ownership_key)` for the "Owned" column (no v2 substring match), and tests covering malicious prefixes, registry ports, tags, digests, and empty sets. (CONCERN 4)
+- **`OwnershipPolicy.matches` narrowed for strict type checking.** `self._normalised` is read into a local `normalised` variable; the function returns `False` if `normalised is None`, otherwise tests membership. Pyright strict mode can now infer the invariant. (CONCERN 5)
+- **Unused imports removed.** `Iterable` and `StrEnum` are no longer imported in `cleanup_policy.py`; `Optional` is no longer imported in `providers/vastai.py`. (NIT 6)
+
+### Applied from the 8th-pass review (fifth pass)
+
+- Module ownership corrected (destroy types in `providers.destroy`, imports in adapter and runner).
+- `read_vastai_api_key` env-first.
+- Empty `--allowed-images` fail-closed.
+- Null provider ID rejected.
+- `destroy_fn` return type validated.
+- `NO_CREDENTIALS` WARNING.
+- `VastaiRunner.destroy_instance` typed logging.
 
 ### Applied from the 7th-pass review (fourth pass)
 
-- ABSENT-credential CLI fallback (factory intercepts `NO_CREDENTIALS`).
-- Correct v3 `DestroyResult` translation (no `result.error`, use `_describe()`).
-- `VastaiRunner.destroy_instance` delegation (superseded by CONCERN 8 above).
-- Non-empty catch error (`f"{type(exc).__name__}: {exc}"`).
-- `build_vastai_cleanup_policy(*, ownership, credentials)` direct args.
-- `instance_id` non-empty validation (superseded by BLOCKER 5 above).
-- `_normalised` declared as `field(init=False, repr=False, compare=False)`.
-- `CredentialState(StrEnum)`.
-- `VASTAI_TERMINAL_STATES` (negative allowlist).
-- Severity logging (LEAKED = ERROR, etc.).
-- `--allowed-images` canonical (superseded by BLOCKER 4 above).
-- Historical `is_candidate` reference removed.
+- ABSENT-credential CLI fallback.
+- Correct v3 `DestroyResult` translation.
+- `VastaiRunner.destroy_instance` delegation.
+- Non-empty catch error.
 
 ### Applied from the 6th-pass review (third pass)
 
-- `_repository(image_ref)` strips digest, strips only the final tag separator, preserves registry and port.
+- `_repository` strips digest, strips only the final tag separator, preserves registry and port.
 - Runner and adapter consume `OwnershipPolicy.matches()` directly.
-- v3 type names used exactly.
 - `EXPLICITLY_DISABLED` short-circuits before enumeration.
-- `docker_image` non-empty + pre-stripped invariant.
-- Undefined names fixed (logger import, OwnershipPolicy imports).
+- `docker_image` non-empty invariant.
 - `CleanupResult` invariants tightened.
-- Authoritative eligibility implemented (later replaced by negative terminal-states list).
-- `InstanceCandidate` enriched with `gpu_model`, `cost_per_hour`, `ownership_key`.
+- Authoritative eligibility (later replaced by negative terminal-states list).
 
 ### Applied from the 5th-pass review (second pass)
 
@@ -138,28 +147,30 @@ fifth draft addresses every finding.
 - `list_instances_fn` + `list_instances()` method on the policy.
 - `destroy()` is authoritative.
 - Hostile check removed.
-- `OwnershipPolicy.matches()` introduced.
 - CLI uses `dataclasses.replace`.
 - Provider factories moved to `providers/vastai.py`.
-- `CleanupResult` invariants added.
-- `from_runpod_config` removed.
 - Migration order revised.
+
+### Applied from the 5th-pass review (first draft)
+
+- Initial structural fixes from the first review.
 
 ## Module taxonomy
 
-The v4 doc adds one new module at the layer above the v3 destroy
-protocol. The `CloudRunner` ABC, `BatchOrchestrator`, `unit_lifecycle`,
-`providers/destroy`, and `providers/destroy_adapters/vastai` are
-unchanged in shape (v3 implementation is still a prerequisite).
+The v4 doc adds one new module (`cleanup_policy.py`) and modifies two
+existing modules (`providers/destroy_adapters/vastai.py` and
+`providers/vastai.py`). The v3 modules (`providers/destroy.py`,
+`unit_lifecycle.py`, `BatchOrchestrator`, `CloudRunner`) are
+referenced unchanged.
 
 ### Module ownership (clarified)
 
-| Module | Owns |
-|---|---|
-| `providers/destroy.py` (v3) | `DestroyVerdict`, `DestroyRefusal`, `DestroyResult` (canonical destroy types) |
-| `providers/destroy_adapters/vastai.py` (v3 + v4) | `CredentialState`, `CredentialResolution`, `read_vastai_api_key()` (env-first), `destroy_vastai_instance()` (amended signature: `ownership: OwnershipPolicy`, `credentials: CredentialResolution \| None`) |
-| `providers/vastai.py` (v4) | `VastaiProviderConfig`, `VastaiRunner` (delegates destroy to v3 adapter), `vastai_cmd`, `verify_instance_ownership`, `list_vastai_instances()`, `build_vastai_cleanup_policy()`, `VASTAI_TERMINAL_STATES` |
-| `cleanup_policy.py` (v4) | `OwnershipPolicy`, `InstanceCandidate`, `CleanupVerdict`, `CleanupRefusal`, `CleanupResult`, `ProviderCleanupPolicy` |
+| Module | Owns | v4 changes |
+|---|---|---|
+| `providers/destroy.py` (v3 prerequisite) | `DestroyVerdict`, `DestroyRefusal`, `DestroyResult`, `VerifyVerdict`, `VerifyResult`, `DestroyPolicy`, callback protocols, `belt_and_suspenders` | None — referenced verbatim |
+| `providers/destroy_adapters/vastai.py` (v3 + v4) | `CredentialState`, `CredentialResolution`, `read_vastai_api_key()` (env-first), `destroy_vastai_instance()` (amended signature) | Env-first credentials; amended adapter signature |
+| `providers/vastai.py` (v4) | `VastaiProviderConfig`, `VastaiRunner`, `vastai_cmd`, `verify_instance_ownership`, `list_vastai_instances()`, `build_vastai_cleanup_policy()`, `_describe_destroy_result`, `VASTAI_TERMINAL_STATES` | Many (see diff) |
+| `cleanup_policy.py` (v4) | `OwnershipPolicy`, `InstanceCandidate`, `CleanupVerdict`, `CleanupRefusal`, `CleanupResult`, `ProviderCleanupPolicy` | New module |
 
 The core `cleanup_policy.py` module imports nothing from `providers/`.
 The `providers/vastai.py` module imports from both `providers/destroy`
@@ -213,9 +224,10 @@ RunPod adapter (roadmap item 2).
 ├─────────────────────────────────────────────────┤
 │  unit_lifecycle (unit_lifecycle.py)             │  v3: decision tree, no side effects
 ├─────────────────────────────────────────────────┤
-│  providers/destroy (providers/destroy.py)       │  v3: canonical DestroyResult types
-│    └── DestroyVerdict | DestroyRefusal |        │
-│        DestroyResult                            │
+│  providers/destroy (providers/destroy.py)       │  v3 PREREQUITE: belt-and-suspenders
+│    └── DestroyVerdict | DestroyRefusal |        │  protocol + canonical types
+│        DestroyResult | belt_and_suspenders |   │
+│        DestroyPolicy | callback protocols       │
 ├─────────────────────────────────────────────────┤
 │  providers/destroy_adapters/vastai.py           │  v3 + v4: Vast.ai adapter
 │    └── CredentialState | CredentialResolution | │
@@ -239,9 +251,8 @@ imports and references resolve within one block.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
 from dataclasses import dataclass, field
-from enum import Enum, StrEnum
+from enum import Enum
 from typing import AbstractSet, Callable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -340,15 +351,23 @@ class OwnershipPolicy:
         the tag-insensitive repository of ``image_ref`` matches
         the tag-insensitive repository of any entry in
         ``owned_images``.
+
+        The local ``normalised`` variable narrows the
+        ``_normalised`` type so Pyright strict mode can infer the
+        cross-field invariant (when ``owned_images is not None``,
+        ``_normalised`` is a frozenset, not None).
         """
+        normalised = self._normalised
         if self.owned_images is None:
             return True
+        if normalised is None:
+            return False
         if not image_ref:
             return False
         repo = _repository(image_ref)
         if not repo:
             return False
-        return repo in self._normalised
+        return repo in normalised
 
 
 # ---------------------------------------------------------------------------
@@ -504,7 +523,7 @@ class ProviderCleanupPolicy:
         on every call, then delegates to ``destroy_fn`` which
         applies eligibility / ownership / credential checks.
 
-        Never raises. Two safety guarantees:
+        Never raises. Three safety guarantees:
 
         1. The catch-all uses ``f"{type(exc).__name__}: {exc}"``
            so the error string is always non-empty (preserves
@@ -554,89 +573,12 @@ class ProviderCleanupPolicy:
         return result
 ```
 
-## `providers/destroy.py` — v3 canonical destroy types (NEW)
+## `providers/destroy_adapters/vastai.py` — v3 + v4 amendments
 
-The v3 design places the canonical destroy types here. The v4 design
-uses them unchanged.
-
-```python
-# src/vastai_gpu_runner/providers/destroy.py
-from __future__ import annotations
-
-from dataclasses import dataclass
-from enum import StrEnum
-from typing import Optional
-
-
-class DestroyVerdict(StrEnum):
-    """Outcome verdicts returned by the v3 belt-and-suspenders protocol.
-
-    Three values. ``CLI_ATTEMPTED`` is NOT a v3 verdict — it is a v4
-    ``CleanupVerdict`` produced by the factory's CLI fallback path.
-    """
-    DESTROYED = "destroyed"
-    LEAKED = "leaked"
-    UNKNOWN = "unknown"
-
-
-class DestroyRefusal(StrEnum):
-    """Pre-protocol refusal reasons returned by ``destroy_vastai_instance``."""
-    OWNERSHIP = "ownership"
-    NO_CREDENTIALS = "no_credentials"
-    CREDENTIALS_DISABLED = "credentials_disabled"
-
-
-@dataclass(frozen=True)
-class DestroyResult:
-    """Outcome of the v3 belt-and-suspenders destroy protocol.
-
-    Exactly one of ``verdict`` (DestroyVerdict) or ``refusal``
-    (DestroyRefusal) is set — never both. Optional diagnostic
-    fields carry the per-step status and error context. No
-    generic ``error`` field exists — refusals use the structured
-    refusal reason, verdicts use the per-step diagnostic fields.
-
-    Invariants (enforced in ``__post_init__``):
-        - Exactly one of ``verdict`` / ``refusal`` is set.
-        - Refusals carry no protocol context (the diagnostic
-          fields are at their defaults).
-        - Verdict outcomes require at least one attempt.
-    """
-    verdict: Optional[DestroyVerdict] = None
-    refusal: Optional[DestroyRefusal] = None
-    attempts: Optional[int] = None
-    last_status_code: Optional[int] = None
-    stop_error: Optional[str] = None
-    verify_error: Optional[str] = None
-
-    def __post_init__(self) -> None:
-        if (self.verdict is None) == (self.refusal is None):
-            raise ValueError(
-                "DestroyResult: exactly one of verdict or refusal must be set"
-            )
-        if self.refusal is not None:
-            if (
-                self.attempts is not None
-                or self.last_status_code is not None
-                or self.stop_error is not None
-                or self.verify_error is not None
-            ):
-                raise ValueError(
-                    "DestroyResult: refusal must not carry protocol context"
-                )
-        else:
-            # verdict is set; require at least one attempt.
-            if self.attempts is None or self.attempts < 1:
-                raise ValueError(
-                    "DestroyResult: verdict outcomes require attempts >= 1"
-                )
-```
-
-## `providers/destroy_adapters/vastai.py` — v3 + v4 additions
-
-The credential types + the env-first resolver + the amended
-`destroy_vastai_instance` signature. The adapter imports the
-destroy types from `providers/destroy.py` (not redefined here).
+The v3 design's `CredentialState` + `CredentialResolution` types plus
+the amended `destroy_vastai_instance` signature. The adapter
+**imports** the destroy types from `providers/destroy.py` (v3
+prerequisite); it does not redefine them.
 
 ```python
 # src/vastai_gpu_runner/providers/destroy_adapters/vastai.py
@@ -649,7 +591,6 @@ import time
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Optional
 
 from vastai_gpu_runner.cleanup_policy import OwnershipPolicy
 from vastai_gpu_runner.providers.destroy import (
@@ -760,7 +701,7 @@ def read_vastai_api_key() -> CredentialResolution:
 
 
 # ---------------------------------------------------------------------------
-# destroy_vastai_instance — amended signature
+# destroy_vastai_instance — amended signature (v4)
 # ---------------------------------------------------------------------------
 
 
@@ -768,7 +709,7 @@ def destroy_vastai_instance(
     instance_id: str,
     *,
     ownership: OwnershipPolicy,
-    credentials: Optional[CredentialResolution] = None,
+    credentials: CredentialResolution | None = None,
 ) -> DestroyResult:
     """Stop + delete + verify a Vast.ai instance.
 
@@ -802,10 +743,11 @@ def destroy_vastai_instance(
         return DestroyResult(refusal=DestroyRefusal.CREDENTIALS_DISABLED)
     if resolution.state == CredentialState.ABSENT:
         return DestroyResult(refusal=DestroyRefusal.NO_CREDENTIALS)
-    # AVAILABLE: REST path.
-    # ... ownership check via API, belt-and-suspenders, return
-    # DestroyResult with verdict=DESTROYED/LEAKED/UNKNOWN and the
-    # structured diagnostic fields populated ...
+    # AVAILABLE: REST path. The implementation calls
+    # belt_and_suspenders(stop_fn, delete_fn, verify_fn, *, policy)
+    # from providers/destroy.py, with the v3 policy. The runner
+    # and the cleanup adapter both delegate to this entry point
+    # via this function — they do NOT have inline REST logic.
 ```
 
 ## `providers/vastai.py` — full module updates
@@ -814,8 +756,8 @@ The `VastaiProviderConfig`, `VastaiRunner`, `list_vastai_instances`,
 and `build_vastai_cleanup_policy` shapes. The destroy types are
 imported from `providers/destroy.py`; the credential types and the
 adapter are imported from `providers/destroy_adapters/vastai.py`.
-The local `vastai_cmd` and `verify_instance_ownership` helpers are
-not imported from elsewhere.
+The local `vastai_cmd`, `verify_instance_ownership`, and
+`_describe_destroy_result` helpers are not imported from elsewhere.
 
 ```python
 # src/vastai_gpu_runner/providers/vastai.py
@@ -828,7 +770,7 @@ import time
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import AbstractSet, Optional
+from typing import AbstractSet
 
 from vastai_gpu_runner.cleanup_policy import (
     CleanupRefusal,
@@ -933,6 +875,29 @@ def verify_instance_ownership(
             return False
     logger.info("Instance %s not found in account (already destroyed?)", instance_id)
     return True
+
+
+# ---------------------------------------------------------------------------
+# _describe_destroy_result — single shared diagnostic helper
+# ---------------------------------------------------------------------------
+
+
+def _describe_destroy_result(result: DestroyResult) -> str:
+    """Build diagnostic text from v3 DestroyResult structured fields.
+
+    Single shared helper used by both ``VastaiRunner.destroy_instance``
+    and ``build_vastai_cleanup_policy._destroy``. Includes verdict +
+    refusal so the fallback "unrecognised result" log exposes the
+    actual typed outcome. Handles ``None`` fields gracefully (v3 uses
+    optional diagnostics). Always produces non-empty output.
+    """
+    return (
+        f"verdict={result.verdict!r}, refusal={result.refusal!r}, "
+        f"attempts={result.attempts}, "
+        f"last_status_code={result.last_status_code}, "
+        f"verify_error={result.verify_error!r}, "
+        f"stop_error={result.stop_error!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1122,53 +1087,39 @@ class VastaiRunner(CloudRunner):
             logger.error(
                 "Destroy %s LEAKED — manual review required: %s",
                 instance.instance_id,
-                _describe(result),
+                _describe_destroy_result(result),
             )
         elif result.verdict == DestroyVerdict.UNKNOWN:
             logger.warning(
                 "Destroy %s outcome=UNKNOWN: %s",
                 instance.instance_id,
-                _describe(result),
+                _describe_destroy_result(result),
             )
         elif result.refusal == DestroyRefusal.OWNERSHIP:
             logger.error(
                 "Destroy %s refused (ownership check rejected): %s",
                 instance.instance_id,
-                _describe(result),
+                _describe_destroy_result(result),
             )
         elif result.refusal == DestroyRefusal.NO_CREDENTIALS:
             logger.error(
                 "Destroy %s refused (no credentials): %s",
                 instance.instance_id,
-                _describe(result),
+                _describe_destroy_result(result),
             )
         elif result.refusal == DestroyRefusal.CREDENTIALS_DISABLED:
             logger.error(
                 "Destroy %s refused (credentials disabled): %s",
                 instance.instance_id,
-                _describe(result),
+                _describe_destroy_result(result),
             )
         else:
             logger.error(
                 "Destroy %s returned unrecognised result: %s",
                 instance.instance_id,
-                _describe(result),
+                _describe_destroy_result(result),
             )
         return False
-
-
-def _describe(result: DestroyResult) -> str:
-    """Build diagnostic text from v3 DestroyResult structured fields.
-
-    Handles ``None`` fields gracefully (v3 uses optional diagnostics).
-    Always produces non-empty output.
-    """
-    return (
-        f"attempts={result.attempts}, "
-        f"last_status={result.last_status_code}, "
-        f"verify_error={result.verify_error!r}, "
-        f"stop_error={result.stop_error!r}"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -1372,7 +1323,8 @@ def build_vastai_cleanup_policy(
                 refusal=CleanupRefusal.OWNERSHIP,
                 error=(
                     f"v3 adapter refused: ownership check rejected "
-                    f"{candidate.instance_id!r}"
+                    f"{candidate.instance_id!r}; "
+                    f"{_describe_destroy_result(result)}"
                 ),
             )
         if result.refusal == DestroyRefusal.CREDENTIALS_DISABLED:
@@ -1400,20 +1352,6 @@ def build_vastai_cleanup_policy(
         ownership=ownership,
         list_instances_fn=_list_instances,
         destroy_fn=_destroy,
-    )
-
-
-def _describe_destroy_result(result: DestroyResult) -> str:
-    """Build diagnostic text from v3 DestroyResult structured fields.
-
-    Handles ``None`` fields gracefully (v3 uses optional diagnostics).
-    Always produces non-empty output.
-    """
-    return (
-        f"attempts={result.attempts}, "
-        f"last_status={result.last_status_code}, "
-        f"verify_error={result.verify_error!r}, "
-        f"stop_error={result.stop_error!r}"
     )
 ```
 
@@ -1518,7 +1456,9 @@ The CLI is the one place that builds the canonical config (for the
 runner) and the two canonical objects (for the cleanup policy). It
 threads both into the v3 + v4 entry points. Empty
 `--allowed-images` is **fail-closed** (empty set, reject every
-image), not opt-out.
+image), not opt-out. The `cli.py:instances` command's "Owned"
+column uses `OwnershipPolicy.matches()` (the v2 unsafe substring
+match is removed).
 
 ```python
 # src/vastai_gpu_runner/cli.py (new "batch" subcommand)
@@ -1656,23 +1596,101 @@ def cleanup(
     console.print(f"\nDestroyed {destroyed}/{len(matches)} instance(s).")
 ```
 
+The `cli.py:instances` command migrates to use `list_vastai_instances`
+and the v4 `OwnershipPolicy.matches()` for the "Owned" column. The
+v2 unsafe substring/prefix match is removed.
+
+```python
+# src/vastai_gpu_runner/cli.py (instances command)
+@app.command()
+def instances(
+    verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
+    allowed_images: Annotated[
+        str | None,
+        typer.Option(
+            "--allowed-images",  # canonical
+            "--owned-images",     # alias
+            help=(
+                "Comma-separated Docker images owned by this project. "
+                "Used for the 'Owned' column. Empty string → fail-closed "
+                "(every instance shown as not owned)."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """List active Vast.ai instances with status and ownership info."""
+    _setup_logging(verbose)
+    from rich.console import Console
+    from rich.table import Table
+    from vastai_gpu_runner.cleanup_policy import OwnershipPolicy
+
+    console = Console()
+    candidates = list_vastai_instances()
+    if not candidates:
+        console.print("No active instances.")
+        return
+
+    # Comma trimming matches the cleanup command. None → opt-out.
+    if allowed_images is None:
+        ownership = OwnershipPolicy()
+    else:
+        images = frozenset(
+            item.strip()
+            for item in allowed_images.split(",")
+            if item.strip()
+        )
+        ownership = OwnershipPolicy(owned_images=images)
+
+    table = Table(title=f"{len(candidates)} Active Instance(s)")
+    table.add_column("ID", style="cyan")
+    table.add_column("GPU")
+    table.add_column("Status")
+    table.add_column("Label")
+    table.add_column("$/hr", justify="right", style="green")
+    table.add_column("Owned", justify="center")
+
+    total_hourly = 0.0
+    running = 0
+    for c in candidates:
+        owned = ownership.matches(c.ownership_key)
+        total_hourly += c.cost_per_hour
+        if c.state == "running":
+            running += 1
+        table.add_row(
+            c.instance_id,
+            c.gpu_model,
+            c.state,
+            c.label,
+            f"${c.cost_per_hour:.3f}",
+            "[green]yes[/green]" if owned else "[red]no[/red]",
+        )
+
+    console.print(table)
+    console.print(f"\nRunning: {running}/{len(candidates)}, Total: ${total_hourly:.2f}/hr")
+```
+
 ## Migration checklist
 
-Seven steps. Each step is independently testable but the rollout
-lands as one PR because the intermediate states are not stable.
+Seven steps. The v3 implementation is a **hard prerequisite**:
+either land v3 first or merge v3 as part of the same PR. The v4
+steps then build on v3's `providers/destroy.py` module
+(`DestroyVerdict`, `DestroyRefusal`, `DestroyResult`, `VerifyVerdict`,
+`VerifyResult`, `DestroyPolicy`, callback protocols,
+`belt_and_suspenders`).
 
-1. **Add canonical credential + ownership-policy types + invariants + contract tests.**
-   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with `_repository`; declared `_normalised` cache field).
-   - `providers/destroy.py:DestroyVerdict` (StrEnum: `DESTROYED | LEAKED | UNKNOWN`), `DestroyRefusal` (StrEnum: `OWNERSHIP | NO_CREDENTIALS | CREDENTIALS_DISABLED`), `DestroyResult` (frozen dataclass with `__post_init__` invariants).
-   - `providers/destroy_adapters/vastai.py:CredentialState` (StrEnum) + `CredentialResolution` (frozen dataclass).
-   - Property tests: `OwnershipPolicy.matches` is reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets and malformed references.
-   - `CredentialResolution` invariants: AVAILABLE requires non-empty pre-stripped key; ABSENT and EXPLICITLY_DISABLED require empty key.
-   - `DestroyResult` invariants: exactly one of verdict/refusal, no protocol context on refusals, ≥1 attempt on verdict outcomes.
+1. **Land v3 implementation.** Implement the `unit_lifecycle.py`,
+   `providers/destroy.py` (with `belt_and_suspenders`, `DestroyPolicy`,
+   `DestroyVerdict`, `DestroyRefusal`, `DestroyResult`, `VerifyVerdict`,
+   `VerifyResult`, callback protocols), and `providers/destroy_adapters/vastai.py`
+   (with the v3-shape credential types, `read_vastai_api_key()`,
+   and the amended `destroy_vastai_instance()` signature). This must
+   land first because v4 amends v3's adapter signature and references
+   v3's `DestroyResult` / `DestroyVerdict` / `DestroyRefusal` types.
 
-2. **Amend v3 adapter with v4 signature + env-first resolver.**
-   - `destroy_vastai_instance(instance_id, *, ownership: OwnershipPolicy, credentials: CredentialResolution | None = None) -> DestroyResult`. Back-compat: `credentials=None` calls `read_vastai_api_key()`.
-   - `read_vastai_api_key()` env-first: inspect `VASTAI_API_KEY` first (empty → `EXPLICITLY_DISABLED`, non-empty → `AVAILABLE`); fall back to file paths (blank/unreadable → warning + `ABSENT`, not disabled); catch `OSError`.
-   - Adapter tests: ownership match uses `OwnershipPolicy.matches()`; credential state drives refusal type; AVAILABLE runs the REST path; ABSENT returns `NO_CREDENTIALS`; EXPLICITLY_DISABLED returns `CREDENTIALS_DISABLED`.
+2. **Add canonical ownership-policy type + invariant tests.**
+   - `cleanup_policy.py:OwnershipPolicy` (frozen, `matches(image_ref)` with `_repository`; declared `_normalised` cache field, narrowed for strict type checking).
+   - Property tests: `OwnershipPolicy.matches` is reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets, malformed reference rejection.
+   - The `_normalised` is precomputed in `__post_init__`; `matches` is O(1) per call.
 
 3. **Add Vast.ai runner + cleanup adapter.**
    - `providers/vastai.py:VastaiProviderConfig` (frozen, with `__post_init__` invariants).
@@ -1682,6 +1700,7 @@ lands as one PR because the intermediate states are not stable.
    - `verify_instance_ownership(instance_id, *, ownership: OwnershipPolicy)` — local to `providers/vastai.py`, replaces `_image_is_allowed`.
    - `list_vastai_instances()` returns `list[InstanceCandidate]`; validates `inst` is dict, `id` is not `None`, `instance_id` is non-empty after strip.
    - `VASTAI_TERMINAL_STATES: frozenset[str]` module constant.
+   - `_describe_destroy_result(result)` — single shared diagnostic helper with `verdict` + `refusal` + structured fields.
    - `build_vastai_cleanup_policy(*, ownership: OwnershipPolicy, credentials: CredentialResolution) -> ProviderCleanupPolicy`.
    - Adapter tests:
      - EXPLICITLY_DISABLED: `list_instances()` returns `[]` without invoking `vastai_cmd`.
@@ -1705,7 +1724,7 @@ lands as one PR because the intermediate states are not stable.
 5. **Update every composition root, subclass, and existing CLI command.**
    - `cli.py:batch`: build `VastaiProviderConfig` via `from_env()` + `replace()`, pass to `VastaiRunner.from_config` and `build_vastai_cleanup_policy(ownership, credentials)`.
    - `cli.py:cleanup`: build `OwnershipPolicy` and `CredentialResolution` directly (no `VastaiProviderConfig`); distinguish `None` (opt-out) from `""` (fail-closed).
-   - `cli.py:instances`: use `list_vastai_instances()` for the table. `--allowed-images` canonical, `--owned-images` alias.
+   - `cli.py:instances`: use `list_vastai_instances()` for the table; construct `OwnershipPolicy` (with comma trimming like `cleanup`); call `ownership.matches(candidate.ownership_key)` for the "Owned" column. The v2 unsafe substring/prefix match (`any(img.split(":")[0] in image for img in images_set)`) is **removed**.
    - `BatchOrchestrator` subclasses: update composition to supply `cleanup_policy`.
    - Test fixtures: `VastaiProviderConfig` + `OwnershipPolicy` + `CredentialResolution` factory fixtures.
 
@@ -1724,12 +1743,14 @@ lands as one PR because the intermediate states are not stable.
      - **CLI --allowed-images None**: opt-out (every image considered owned).
      - **destroy_fn returns None**: orchestrator receives `CleanupResult(verdict=UNKNOWN, error="...invalid result type NoneType")`.
      - **VastaiRunner logs typed result**: LEAKED outcome produces an `ERROR`-level log line with the structured diagnostic context.
+     - **instances command ownership column**: malicious prefix `myorg/app-malicious:latest` shown as `no` when `--allowed-images myorg/app:1.0`; tag-insensitive `myorg/app:latest` shown as `yes`; registry-port `registry:5000/myorg/app:1.0` shown as `no` when `--allowed-images myorg/app`; empty set `--allowed-images ""` shows every instance as `no`.
 
 7. **Delete legacy sweep + duplicated helpers after a repository-wide caller audit.**
-   - `audit_caller_sites.sh` (run before deletion): grep for external callers of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use), `providers.vastai._image_is_allowed`. Update external callers.
+   - `audit_caller_sites.sh` (run before deletion): grep for external callers of `orchestrator.sweep_zombie_instances`, `orchestrator.load_vastai_api_key`, `VastaiRunner.allowed_images` (read-only external use), `providers.vastai._image_is_allowed`, `cli.instances`'s substring match. Update external callers.
    - Delete `orchestrator.sweep_zombie_instances`.
    - Delete `orchestrator.load_vastai_api_key`.
    - Delete `providers/vastai.py:_image_is_allowed`.
+   - Delete the v2 substring/prefix match in `cli.py:instances`.
    - Delete direct `vastai_cmd(["show", "instances", "--raw"])` parsing in `cli.py:cleanup` and `cli.py:instances`.
    - Update `tests/test_orchestrator.py` and `tests/test_batch.py` to mock `cleanup_policy.list_instances` and `cleanup_policy.destroy`.
 
@@ -1737,14 +1758,12 @@ lands as one PR because the intermediate states are not stable.
 
 - `tests/test_cleanup_policy.py`:
   - `_repository`: 13+ cases (digest, registry ports, malformed, empty, whitespace).
-  - `OwnershipPolicy.matches`: reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets, malformed reference rejection.
+  - `OwnershipPolicy.matches`: reflexive, tag-insensitive, sha256-by-repo, registry-port-aware, fail-closed on empty sets, malformed reference rejection, narrow type-checked.
   - `OwnershipPolicy._normalised`: declared field; precomputed in `__post_init__`; `matches` is O(1) per call.
   - `ProviderCleanupPolicy.list_instances`: returns wired list; catches and returns `[]` on exception.
   - `ProviderCleanupPolicy.destroy`: provider mismatch returns `PROVIDER_MISMATCH`; catches `destroy_fn` exceptions with `f"{type(exc).__name__}: {exc}"` (non-empty even for `RuntimeError()` with no message); validates `destroy_fn` return is `CleanupResult` (returns `CleanupResult(verdict=UNKNOWN, ...)` on `None` or non-`CleanupResult`).
   - `CleanupResult` invariants: 5 cases (verdict/refusal exclusivity, error non-empty on non-DESTROYED, error empty on DESTROYED).
   - `InstanceCandidate.__post_init__`: empty `instance_id` raises; whitespace-only `instance_id` raises.
-- `tests/test_providers_destroy.py`:
-  - `DestroyResult` invariants: exactly one of verdict/refusal; refusal must not carry protocol context; verdict requires ≥1 attempt.
 - `tests/test_providers_vastai.py`:
   - `read_vastai_api_key` env-first: `VASTAI_API_KEY=""` → `EXPLICITLY_DISABLED`; `VASTAI_API_KEY="key"` → `AVAILABLE`; no env + file → `AVAILABLE`; no env + blank file → `ABSENT` (with warning); `OSError` → `ABSENT` (with warning).
   - `VastaiRunner.from_config` round-trips with `VastaiProviderConfig`.
@@ -1767,7 +1786,7 @@ lands as one PR because the intermediate states are not stable.
   - `_sweep_zombies` logs `LEAKED` at `ERROR`, `UNKNOWN` / `CLI_ATTEMPTED` / `CREDENTIALS_DISABLED` at `WARNING`, unexpected `NO_CREDENTIALS` at `WARNING`, refusals at `INFO` (`caplog`).
   - `_sweep_zombies` continues on `destroy_fn` exceptions.
   - `_sweep_zombies` does NOT import provider modules (`inspect.getsource`).
-- `tests/integration/test_cleanup_policy_integration.py` — 13 scenarios from step 6 above.
+- `tests/integration/test_cleanup_policy_integration.py` — 14 scenarios from step 6 above.
 
 ## Backwards compatibility
 
@@ -1785,7 +1804,8 @@ The `cli.py:cleanup` and `cli.py:instances` commands are refactored
 in v4 step 5. The `--allowed-images` flag is preserved as canonical;
 `--owned-images` is added as a documented alias. Empty
 `--allowed-images ""` is **fail-closed** (not opt-out) — this is a
-behaviour change from the previous CLI default.
+behaviour change from the previous CLI default. The v2 substring
+match in `cli.py:instances` is removed.
 
 ## Out of scope
 
@@ -1800,11 +1820,11 @@ behaviour change from the previous CLI default.
 
 ## Review process
 
-This is the fifth review pass on the v4 architecture. Each prior
+This is the sixth review pass on the v4 architecture. Each prior
 draft was rejected and addressed. This draft addresses every
-finding from the 8th-pass review.
+finding from the 9th-pass review.
 
-The fifth review prompt for ChatGPT-with-GitHub-plugin:
+The sixth review prompt for ChatGPT-with-GitHub-plugin:
 
 > Review the v4 architecture design at PR #22 (file:
 > docs/architecture-v4-cleanup-policy.md) against the v3 design at
@@ -1813,83 +1833,77 @@ The fifth review prompt for ChatGPT-with-GitHub-plugin:
 > src/vastai_gpu_runner/providers/vastai.py. The v4 design
 > resolves issue #19.
 >
-> The fourth draft was rejected with 5 BLOCKERs and 3 CONCERNs.
-> Verify each finding is addressed:
+> The fifth draft was rejected with 2 BLOCKERs, 2 CONCERNs, and
+> 1 NIT. Verify each finding is addressed:
 >
-> 1. **BLOCKER 1 (module ownership)**: confirm
->    `DestroyVerdict` / `DestroyRefusal` / `DestroyResult` are
->    defined in `providers/destroy.py` (NOT in the Vast.ai
->    adapter). Confirm `providers/vastai.py` imports them from
->    `providers.destroy`, not from
->    `providers.destroy_adapters.vastai`. Confirm `vastai_cmd`
->    and `verify_instance_ownership` are local to
->    `providers/vastai.py` (no import from the adapter).
-> 2. **BLOCKER 2 (env-first credentials)**: confirm
->    `read_vastai_api_key()` inspects `VASTAI_API_KEY` first
->    (empty → `EXPLICITLY_DISABLED`, non-empty → `AVAILABLE`),
->    then falls back to file paths (blank/unreadable → warning +
->    `ABSENT`). Confirm `OSError` is caught.
-> 3. **BLOCKER 3 (DestroyResult verbatim)**: confirm
->    `DestroyResult` is NOT redefined in the adapter; confirm
->    the v3 types from `providers.destroy` use optional fields
->    and `__post_init__` invariants. Confirm `_describe()`
->    handles `None` fields.
-> 4. **BLOCKER 4 (empty --allowed-images fail-closed)**:
->    confirm the cleanup CLI distinguishes `None` (opt-out)
->    from `""` (fail-closed empty set). Confirm whitespace-only
->    entries in comma-separated input are stripped.
-> 5. **BLOCKER 5 (null ID rejected)**: confirm
->    `list_vastai_instances` checks `inst` is a dict, then
->    checks `inst.get("id") is None` explicitly (catches
->    JSON `null` before `str()` converts to `"None"`).
-> 6. **CONCERN 6 (destroy_fn return validated)**: confirm
->    `ProviderCleanupPolicy.destroy()` checks `isinstance(result,
->    CleanupResult)` and substitutes `CleanupResult(verdict=UNKNOWN,
->    ...)` when the callback returns `None` or non-`CleanupResult`.
-> 7. **CONCERN 7 (NO_CREDENTIALS WARNING)**: confirm unexpected
->    `NO_CREDENTIALS` is logged at `WARNING`, not `INFO`.
-> 8. **CONCERN 8 (runner logs typed result)**: confirm
->    `VastaiRunner.destroy_instance` logs the typed
->    `DestroyResult` (verdict/refusal + diagnostic context)
->    before returning `False` for non-`DESTROYED` outcomes.
+> 1. **BLOCKER 1 (DestroyResult verbatim)**: confirm the v4 doc
+>    does NOT redefine `DestroyResult`. The doc should reference
+>    v3's `providers/destroy.py` module as the authoritative
+>    source for `DestroyResult`, `DestroyVerdict`, `DestroyRefusal`.
+>    The v3 contract (per the reviewer) is:
+>    ```python
+>    attempts: int = 0
+>    stop_error: str | None = None
+>    last_status_code: int | None = None
+>    verify_error: str | None = None
+>    ```
+>    with refusal requiring `attempts == 0` and verdict requiring
+>    `attempts >= 1`. The v4 doc should not contradict this.
+> 2. **BLOCKER 2 (providers/destroy.py incomplete)**: confirm the
+>    v4 doc does NOT include a `providers/destroy.py` code block.
+>    The v3 prerequisite module is referenced as authoritative;
+>    v4 only amends the adapter's `destroy_vastai_instance`
+>    signature. Migration step 1 makes v3 implementation a hard
+>    prerequisite.
+> 3. **CONCERN 3 (duplicated _describe, omits verdict/refusal)**:
+>    confirm there is ONE shared `_describe_destroy_result`
+>    helper in `providers/vastai.py`, used by both
+>    `VastaiRunner.destroy_instance` and `build_vastai_cleanup_policy._destroy`.
+>    Confirm the helper includes `verdict` and `refusal` in the
+>    output (not just attempts + errors).
+> 4. **CONCERN 4 (instances command ownership migration)**: confirm
+>    migration step 5 expands the `cli.py:instances` migration:
+>    - construct `OwnershipPolicy` (with comma trimming like `cleanup`)
+>    - use `ownership.matches(candidate.ownership_key)` for the
+>      "Owned" column
+>    - tests covering malicious prefixes, registry ports, tags,
+>      digests, empty sets
+> 5. **CONCERN 5 (_normalised narrowing)**: confirm
+>    `OwnershipPolicy.matches` reads `self._normalised` into a
+>    local `normalised` variable and returns `False` if
+>    `normalised is None`, so Pyright strict mode can infer the
+>    invariant.
+> 6. **NIT 6 (unused imports)**: confirm `cleanup_policy.py` no
+>    longer imports `Iterable` or `StrEnum`; confirm
+>    `providers/vastai.py` no longer imports `Optional` (in the
+>    shown code).
 >
 > Additionally, identify any new BLOCKERs or CONCERNs introduced
-> by the fifth draft. Focus on:
+> by the sixth draft. Focus on:
 >
-> - The module boundary: does `providers/vastai.py` import
->   `DestroyRefusal` / `DestroyResult` / `DestroyVerdict` ONLY
->   from `providers.destroy` (and NOT from the adapter)?
-> - The env-first `read_vastai_api_key`: does the env-var
->   branch correctly handle `os.environ.get("VASTAI_API_KEY")`
->   returning `None` (unset), empty string, whitespace, and
->   non-empty?
-> - The `DestroyResult.__post_init__` invariants: does
->   `attempts >= 1` correctly accept `attempts=1`?
-> - The `_describe()` helpers (one in `providers/vastai.py`,
->   one in the factory): are they duplicated? Should they be
->   shared? Or are they acceptably local?
-> - The `list_vastai_instances` validation order: is the
->   `isinstance(inst, dict)` check before `inst.get("id")`?
->   Does the outer `try` block still catch `AttributeError`
->   on a non-dict element?
-> - The `build_vastai_cleanup_policy` import: does the
->   factory import `DestroyRefusal` / `DestroyResult` /
->   `DestroyVerdict` from `providers.destroy` (NOT from the
->   adapter)?
-> - The CLI cleanup command: does the empty `--allowed-images`
->   handling correctly distinguish `None` vs `""` vs
->   `","` vs `"a, ,b"`?
-> - The `VastaiRunner.destroy_instance` typed logging: is the
->   `_describe()` call correct? Are the log levels appropriate?
-> - The orchestrator's `NO_CREDENTIALS` WARNING: does the
->   conditional correctly handle the case where `refusal ==
->   NO_CREDENTIALS` but `verdict is None`?
-> - The `DestroyResult` invariants and the `_describe()` helper:
->   when `result.attempts is None` (shouldn't happen after
->   `__post_init__`, but defensively), does `_describe()`
->   produce non-empty output?
-> - The migration step 5: are the CLI changes correctly
->   described?
+> - The v3 prerequisite: does the migration checklist make it
+>   clear that v3 must be implemented first? Are the v3 module
+>   dependencies correctly listed (belt_and_suspenders,
+>   DestroyPolicy, VerifyVerdict, VerifyResult, callback
+>   protocols)?
+> - The `_describe_destroy_result` helper: is it called from
+>   both the runner's typed-result logging and the factory's
+>   refusal/verdict translation? Does it include all four
+>   structured fields plus verdict + refusal?
+> - The instances command code shape: does it correctly
+>   construct `OwnershipPolicy` with comma trimming? Does it use
+>   `ownership.matches(candidate.ownership_key)` (not the v2
+>   substring match)?
+> - The `OwnershipPolicy.matches` narrowing: does Pyright strict
+>   mode accept the local-variable pattern?
+> - The cleanup policy's `_destroy` callback: does it correctly
+>   call `_describe_destroy_result` for both verdict and refusal
+>   paths?
+> - The runner's `destroy_instance`: does it correctly log all
+>   typed outcomes (verdict + refusal + diagnostic context)?
+> - The migration checklist: are the v3 prerequisites explicit?
+> - The unused imports: any other imports that are no longer
+>   used?
 >
 > Return a labeled list of findings. Each finding is one of:
 > BLOCKER (must fix before merge), CONCERN (should fix, but not


### PR DESCRIPTION
Resolves #19.

This doc layers on top of v3 to define the long-term shape for the zombie-sweep + ownership-guard policy. The v3 design (architecture-v3.md, merged) named this as the v3 step 12 follow-up.

Highlights:
- One canonical config (`VastaiProviderConfig`) shared by both the runner factory and the cleanup policy — no per-destroy runner construction, no drift between the runner's destroy_instance ownership guard and the zombie sweep's ownership guard.
- `ProviderCleanupPolicy` is a frozen dataclass with two methods (`is_candidate`, `destroy`) and three refusal enum members (`UNOWNED | NO_CREDENTIALS | CREDENTIALS_DISABLED`).
- `InstanceCandidate` is a read-only DTO returned by a new `list_vastai_instances` helper so the orchestrator never parses Vast.ai JSON.
- The orchestrator's `_sweep_zombies` is policy-driven: it calls `cleanup_policy.is_candidate(candidate)` then `cleanup_policy.destroy(candidate)`. The orchestrator no longer imports any provider-specific destroy function.
- RunPod path is defined as a stub (`from_runpod_config` raises NotImplementedError) so the shape is forward-compatible when the RunPod adapter ships.

7-step migration checklist, test plan, and the ChatGPT review prompt are included.

Review iteration: ChatGPT-with-GitHub-plugin like the v3 doc. The first review prompt is in the doc's "Review process" section.